### PR TITLE
Create the block folder at boot

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -5,6 +5,7 @@ const Decrees = require("./decrees");
 
 const nThen = require("nthen");
 const Fs = require("fs");
+const Fse = require("fs-extra");
 const Path = require("path");
 
 module.exports.create = function (Env) {
@@ -22,8 +23,18 @@ nThen(function (w) {
         }
     }));
 }).nThen(function (w) {
+    Fse.mkdirp(Env.paths.block, w(function (err) {
+        if (err) { 
+            log.error("BLOCK_FOLDER_CREATE_FAILED", err);
+        }
+    }));
+}).nThen(function (w) {
     var fullPath = Path.join(Env.paths.block, 'placeholder.txt');
-    Fs.writeFile(fullPath, 'PLACEHOLDER\n', w());
+    Fs.writeFile(fullPath, 'PLACEHOLDER\n', w(function (err) {
+        if (err) {
+            log.error('BLOCK_PLACEHOLDER_CREATE_FAILED', err);
+        }
+    }));
 }).nThen(function () {
     // asynchronously create a historyKeeper and RPC together
     require('./historyKeeper.js').create(Env, function (err, historyKeeper) {


### PR DESCRIPTION
# The bug

Currently, `Fs.writeFile(fullPath, 'PLACEHOLDER\n', w());` always fails silently.
It fails **silently** because the error is not checked on `Fs.writeFile`.
And it **fails** because the block folder is not created before we try to write the file.

# Behaviour on the `/checkup` script

As a consequence, the first time you launch the server, the `placeholder.txt` file is not created.
When you run the checkup script, it fails to find the file but creates the missing folder as, as soon you ask to store a proper block, because the called logic has the `Fse.mkdirp` logic, and thus the folder is created. So, on the next restart of Cryptpad, the placeholder.txt file can be created, and magically, the checkup script succeed.

# My patch

I create the block folder and check for error before trying to create `placeholder.txt`, then I also check for error during the `placeholder.txt` file creation.

