### PR TITLE
provide visual feedback that a dragged item can be dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ To upgrade:
 
 ```bash
 git fetch origin --tags
-git checkout 5.3
+git checkout 5.3.0
 ```
 
 1. Restart your server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Goals
 
-This release updates OnlyOffice applications to version 7.3.3. It improves the Form application and other areas of CryptPad with minor features and bug fixes. 
+This release updates OnlyOffice applications to version 7.1 It improves the Form application and other areas of CryptPad with minor features and bug fixes. 
 
 ## Features
 

--- a/customize.dist/src/less2/include/drive.less
+++ b/customize.dist/src/less2/include/drive.less
@@ -291,7 +291,14 @@
             margin-bottom: 3px;
             margin-left: -2px;
         }
+        .droppable-tree-element () {
+            .cp-app-drive-element-droppable {
+                background-color: @cp_drive-droppable-bg !important;
+                color: @cp_drive-droppable-fg !important;
+            }
+        }
         .cp-app-drive-tree-docs {
+            .droppable-tree-element();
             margin-top: 15px;
             //padding: 0 0 0 20px;
             padding: 0;
@@ -346,6 +353,7 @@
             border-radius: @variables_radius;
             box-shadow: @cryptpad_ui_shadow;
             .cp-app-drive-tree-root {
+                .droppable-tree-element();
                 .fa-trash-o {
                     padding-left: 2px;
                 }


### PR DESCRIPTION
> provide visual feedback that a dragged item can be dropped into the drive's tree when hovering

I noticed a while back that dragging an element from the drive's main pane to the tree did trigger any visual feedback while hovering with the element. This made it somewhat unclear whether the item was able to be dropped. Aside from the visual cues, everything does seem to work as expected when the element is dropped, so we just need better styles.

This PR adds those styles to the main document tree, the templates category, and the trash - but not on un-droppable categories like "recent" or "tags".

The styles are applied using a less mixin, so it should be simple to add any other styles, such as a contextual cursor.