### PR TITLE
add form title to archived notifications

### DIFF
--- a/www/common/sframe-common-mailbox.js
+++ b/www/common/sframe-common-mailbox.js
@@ -271,7 +271,11 @@ define([
                     messages.push({
                         type: type,
                         content: {
-                            msg: data.message,
+                            msg: Object.assign(data.message, {
+                                content: Object.assign(data.message.content, {
+                                   title: data.message.content.data.title,
+                                }),
+                            }),
                             time: data.time,
                             hash: data.hash
                         }

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -3599,7 +3599,7 @@ define([
                     send: true,
                     anon: true,
                     query: "FORM_RESPONSE",
-                    msgData: { channel: priv.channel }
+                    msgData: { channel: priv.channel, title: framework._.title.title || framework._.title.defaultTitle },
                 }, function (err, obj) {
                     if (err || !obj || !obj.state) { return console.error('ENOTIFY'); }
                 });
@@ -4756,7 +4756,7 @@ define([
             var endDateStr = h('div');
             var $endDate = $(endDateContainer);
             var $endDateStr = $(endDateStr);
-        
+
             var refreshEndDate = function () {
                 $endDate.empty();
 


### PR DESCRIPTION
Fixes #1060 

Notifications in CryptPad have two versions AFAIK, one that sends the notification to the active WebSocket and one that is stored in ./datastore/{HASH}/{HASH}.ndjson

Theoretically, the notifications sent by ./www/form/inner.js are privitized by the server when archived. I haven't confirmed this but it seems that the server, when sending the websocket notification, either fetches the form's data or removes it when storing the notification in data store. (your guess is as good as mine)

Anyhoo, this fix is a bit hacky since it just adds a title field to the notification:
```js
// ./www/form/inner.js:3597
// previous
msgData: { channel: priv.channel }
// current
msgData: { channel: priv.channel, title: framework._.title.title || framework._.title.defaultTitle }
```

Then, it assigns the title in the "right" place because a title in the data field of a notification will not be used.
```js
// ./www/common/sframe-common/mailbox.js:270
// previous
messages.push({
	// ... other fields
	content: {msg: data.message, time: data.time, hash: data.hash},
	// ... other fields
})
// current
messages.push({
	// ... other fields
	content: {
		// ... other fields
		msg: Object.assign(data.message, {
			content: Object.assign(data.message.content, {
				title: data.message.content.data.title,
			})
		},
		// ... other fields
	}
	// ... other fields
})
```

(above code examples are not 100% accurate and are used for presentation purposes...)