### PR TITLE
add a "make a copy" element to onlyoffice applications

### DIFF
--- a/www/common/onlyoffice/inner.js
+++ b/www/common/onlyoffice/inner.js
@@ -2849,6 +2849,9 @@ Uncaught TypeError: Cannot read property 'calculatedType' of null
 
             var $properties = common.createButton('properties', true);
             toolbar.$drawer.append($properties);
+            
+            var $copy = common.createButton('copy', true);
+            toolbar.$drawer.append($copy);
         };
 
         var noCache = false; // Prevent reload loops

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1350,7 +1350,7 @@ define([
                     channel: secret.channel,
                     href: currentPad.href,
                     password: password,
-                    title: currentTitle + " (copy)",
+                    title: currentTitle
                 };
                 var obj = { d: data };
                 var href = window.location.pathname;

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1350,7 +1350,7 @@ define([
                     channel: secret.channel,
                     href: currentPad.href,
                     password: password,
-                    title: currentTitle
+                    title: currentTitle + " (copy)",
                 };
                 var obj = { d: data };
                 var href = window.location.pathname;


### PR DESCRIPTION
Fixes #1061

This commit adds a 'Make A Copy' to all onlyoffice applications theortically. Though, I only tested sheets since that's all I had in my toolset.

The toolbar works through adding buttons with 'createButton' in `./www/common/common-ui-elements.js:569` and there are (thankfully) premade buttons. That means that buttons like 'Export', 'Make A Copy', 'Import', etc can be created by supplying the type and a boolean indicating the right side.

But most uses of createButton are through
`./www/common/sframe-common.js:106` which is the same underlying function of `common-ui-elements.js` but with the first two arguments skipped.

Anyhoo, this was long. Basically, all this commit does is add two lines at `./www/common/onlyoffice/inner.js:2851`.