### PR TITLE
add " (copy)" to copied OpenOffice files

### DIFF
--- a/www/common/onlyoffice/inner.js
+++ b/www/common/onlyoffice/inner.js
@@ -242,7 +242,8 @@ define([
                 title = "download";
             }
             if(title === "" && APP.startWithTemplate) {
-                var copyTitle = Messages._getKey('copy_title', [APP.startWithTemplate.content.metadata.title]);
+                var metadata = APP.startWithTemplate.content.metadata;
+                var copyTitle = Messages._getKey('copy_title', [metadata.title || metadata.defaultTitle]);
                 common.getMetadataMgr().updateTitle(copyTitle);
                 title = copyTitle;
             }

--- a/www/common/onlyoffice/inner.js
+++ b/www/common/onlyoffice/inner.js
@@ -241,6 +241,11 @@ define([
                 type = APP.downloadType;
                 title = "download";
             }
+            if(title === "" && APP.startWithTemplate) {
+                var copyTitle = Messages._getKey('copy_title', [APP.startWithTemplate.content.metadata.title]);
+                common.getMetadataMgr().updateTitle(copyTitle);
+                title = copyTitle
+            }
             var file = {};
             switch(type) {
                 case 'doc':

--- a/www/common/onlyoffice/inner.js
+++ b/www/common/onlyoffice/inner.js
@@ -244,7 +244,7 @@ define([
             if(title === "" && APP.startWithTemplate) {
                 var copyTitle = Messages._getKey('copy_title', [APP.startWithTemplate.content.metadata.title]);
                 common.getMetadataMgr().updateTitle(copyTitle);
-                title = copyTitle
+                title = copyTitle;
             }
             var file = {};
             switch(type) {


### PR DESCRIPTION
Fixes #1073 

Normally, copied CryptPad files have a " (copy)" suffixed to them but OnlyOffice doesn't because it has different internal architechture.

Copied OnlyOffice files can be identified by two attributes: a non-empty title and template data.

Since OnlyOffice files cannot be just copy and pasted, I resorted to modifying their metadata through metadataMgr in `./www/common/onlyoffice/inner.js:244`

Essentially, this commit check if a file is a copied file. If it is, it updates the title. It doesn't actually copy the file but merely modifies the title after it has been copied.

Note: I only tested this on OnlyOffice Sheets because I couldn't figure out how to run the other OnlyOffice applications.