### PR TITLE
add vertical padding to Kanban card container

### DIFF
--- a/www/kanban/app-kanban.less
+++ b/www/kanban/app-kanban.less
@@ -546,7 +546,7 @@
             display: flex;
             min-height: 0;
             .kanban-container {
-                padding: 0px 5px;
+                padding: 30px 5px;
                 flex: 1;
                 display: flex;
                 max-height: 100%;


### PR DESCRIPTION
Fixes #1039 

This commit adds some padding to the cards container in Kanban for better mobile user experience.

Here is a demo:
https://cryptpad.fr/file/#/2/file/z8X7DfDPkNVwepC3kaMbH0S5/