### PR TITLE
add even space between category buttons

### DIFF
--- a/customize.dist/src/less2/include/sidebar-layout.less
+++ b/customize.dist/src/less2/include/sidebar-layout.less
@@ -142,7 +142,7 @@
                 padding-bottom: 20px;
                 .cp-sidebarlayout-categories {
                     .cp-sidebarlayout-category {
-                        margin: 0;
+                        margin: 10px 0px;
                         span.cp-sidebar-layout-category-name {
                             display: inline !important; // override "narrow" mode
                         }


### PR DESCRIPTION
Fixes #1101 

Here's a screenshot
![before](https://github.com/cryptpad/cryptpad/assets/62130041/d2adf89d-5041-404b-bb55-a31f003df6f9)

![after](https://github.com/cryptpad/cryptpad/assets/62130041/21d7ace6-8d92-4d3f-ae1a-068a22c2fcf5)
