### PR TITLE
make mobile version of calendar close date field on 2nd button click

### DIFF
--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -1212,23 +1212,34 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
             updateDateRange();
             updateRecurring();
         });
+        var dateFlatpickr;
         $(goDate).click(function () {
-            var f = Flatpickr(goDate, {
-                enableTime: false,
-                defaultDate: APP.calendar.getDate()._date,
-                //dateFormat: dateFormat,
-                onChange: function (date) {
-                    date[0].setHours(12);
-                    f.destroy();
-                    APP.moveToDate(+date[0]);
-                    updateDateRange();
-                    updateRecurring();
-                },
-                onClose: function () {
-                    setTimeout(f.destroy);
-                }
-            });
-            f.open();
+            if(dateFlatpickr) {
+                dateFlatpickr.destroy();
+                dateFlatpickr = null;
+            } else {
+                dateFlatpickr = Flatpickr(goDate, {
+                    enableTime: false,
+                    defaultDate: APP.calendar.getDate()._date,
+                    //dateFormat: dateFormat,
+                    onChange: function (date) {
+                        date[0].setHours(12);
+                        dateFlatpickr.destroy();
+                        APP.moveToDate(+date[0]);
+                        updateDateRange();
+                        updateRecurring();
+                    },
+                    onClose: function () {
+                        if(dateFlatpickr) {
+                            setTimeout(function() {
+                                dateFlatpickr.destroy();
+                                dateFlatpickr = null;
+                            });
+                        }
+                    }
+                });
+                dateFlatpickr.open();
+            }
         });
         APP.toolbar.$bottomL.append(h('div.cp-calendar-browse', [
             goLeft, goToday, goRight, goDate


### PR DESCRIPTION
Fixes #1084

In the Calendar app on mobile, if you click on the calendar date button it shows a date input field and that input field disappears if you set a date. If you don't, the input field stays unless you change the date by clicking on the calendar date button and change the current date.

This fix makes it so that when the calendar date button is clicked and the input field is visible, it makes the input field invisible.

Here's a mobile demo and a desktop demo:
[mobile demo](https://cryptpad.fr/file/#/2/file/lJfZDsiUAmaUdM9hKkLVLWRA/) and [desktop demo](https://cryptpad.fr/file/#/2/file/isIe0V6qOv-WBb1q78YqExfy/).