### PR TITLE
remove unnecessary right padding from all lists in Rich Text(pad)

### DIFF
--- a/customize.dist/ckeditor-contents.css
+++ b/customize.dist/ckeditor-contents.css
@@ -102,6 +102,7 @@ ol,ul,dl
     *margin-right: 0px;
     /* preserved spaces for list items with text direction other than the list. (#6249,#8049)*/
     padding: 0 40px;
+    padding-right: 0px;
 }
 
 h1,h2,h3,h4,h5,h6


### PR DESCRIPTION
closes #1111

the app Rich Text, codename pad, has unnecessary right padding for all lists. This makes it quite frustrating to edit in mobile environments.

This commit basically removes all unnecessary right padding for all lists.

Here's a screenshot on iPhone SE simulation.

![localhost_3000_pad_(iPhone SE) (3)](https://github.com/cryptpad/cryptpad/assets/62130041/9080b604-7825-4630-b382-637d997ab653)