### PR TITLE
Fixed the color of access modal disabled tabs

### DIFF
--- a/customize.dist/src/less2/include/forms.less
+++ b/customize.dist/src/less2/include/forms.less
@@ -49,17 +49,17 @@
                 margin: 0;
                 height: 100%;
                 margin-left: -1px;
-                text-transform: unset !important;
+                tea-xt-transform: unset !important;
                 border-radius: 0 @variables_radius @variables_radius 0;
             }
         }
     }
-    &.enabled {
+    &.mfa-enabled {
         span, i {
             color: @cp_settings_enabled;
         }
     }
-    &.disabled {
+    &.mfa-disabled {
         span, i {
             color: @cp_settings_disabled;
         }

--- a/www/settings/inner.js
+++ b/www/settings/inner.js
@@ -917,7 +917,7 @@ define([
 
     var drawMfa = function (content, enabled) {
         var $content = $(content).empty();
-        $content.append(h('div.cp-settings-mfa-hint.cp-settings-mfa-status' + (enabled ? '.enabled' : '.disabled'), [
+        $content.append(h('div.cp-settings-mfa-hint.cp-settings-mfa-status' + (enabled ? '.mfa-enabled' : '.mfa-disabled'), [
             h('i.fa' + (enabled ? '.fa-check' : '.fa-times')),
             h('span', enabled ? Messages.mfa_status_on : Messages.mfa_status_off)
         ]));


### PR DESCRIPTION
I fixed the regression introduced with the 2FA settings styling, now the disabled tabs are grey instead of red. #1157