### PR TITLE
Add title to iframe of applications

### DIFF
--- a/scripts/add-title-to-inner-html.js
+++ b/scripts/add-title-to-inner-html.js
@@ -1,0 +1,30 @@
+var fs = require("fs");
+
+var titles = {
+	"sheet": "CryptPad - Sheet",
+	"pad": "CryptPad - Rich Text",
+	"kanban": "CryptPad - Kanban",
+	"code": "CryptPad - Code",
+	"form": "CryptPad - Form",
+	"diagram": "CryptPad - Diagram",
+	"slide": "CryptPad - Markdown Slides",
+}
+
+var files = Object.keys(titles).map(function(val) {
+	return {path: "./www/" + val + "/inner.html", name: val};
+});
+
+files.forEach(function(val) {
+	var buf = fs.readFileSync(val.path);
+	var str = buf.toString();
+	if(str.match("<title>")) {
+		return
+	}
+	
+	const data = str.replace(/<head>/, `<head>
+    <title>${titles[val.name]}</title>`);
+	console.log("Writing to", val.path, "\n", data, "\n");
+	// empty the file
+	fs.truncateSync(val.path, 0);
+	fs.writeFileSync(val.path, data);
+})

--- a/www/code/inner.html
+++ b/www/code/inner.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html class="cp-app-noscroll cp-app-print">
 <head>
+    <title>CryptPad - Code</title>
     <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
     <script src="/customize/pre-loading.js?ver=1.1"></script>
     <link href="/customize/src/pre-loading.css?ver=1.0" rel="stylesheet" type="text/css">

--- a/www/form/inner.html
+++ b/www/form/inner.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html class="cp-app-noscroll">
 <head>
+    <title>CryptPad - Form</title>
     <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
     <script src="/customize/pre-loading.js?ver=1.1"></script>
     <link href="/customize/src/pre-loading.css?ver=1.0" rel="stylesheet" type="text/css">

--- a/www/kanban/inner.html
+++ b/www/kanban/inner.html
@@ -2,6 +2,7 @@
 <html class="cp-app-noscroll">
 
 <head>
+    <title>CryptPad - Kanban</title>
     <meta content="text/html; charset=utf-8" http-equiv="content-type" />
     <script src="/customize/pre-loading.js?ver=1.1"></script>
     <link href="/customize/src/pre-loading.css?ver=1.0" rel="stylesheet" type="text/css">

--- a/www/pad/inner.html
+++ b/www/pad/inner.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html class="cp-app-noscroll cp-app-print">
 <head>
+    <title>CryptPad - Rich Text</title>
     <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
     <script src="/customize/pre-loading.js?ver=1.1"></script>
     <link href="/customize/src/pre-loading.css?ver=1.0" rel="stylesheet" type="text/css">

--- a/www/sheet/inner.html
+++ b/www/sheet/inner.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html class="cp-app-noscroll">
 <head>
+    <title>CryptPad - Sheet</title>
     <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
     <script src="/customize/pre-loading.js?ver=1.1"></script>
     <link href="/customize/src/pre-loading.css?ver=1.0" rel="stylesheet" type="text/css">

--- a/www/slide/inner.html
+++ b/www/slide/inner.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html class="cp-app-noscroll cp-app-print">
 <head>
+    <title>CryptPad - Markdown Slides</title>
     <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
     <script src="/customize/pre-loading.js?ver=1.1"></script>
     <link href="/customize/src/pre-loading.css?ver=1.0" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Closes #1159 

Issue 1159 is about the inner files of the applications. This PR adds a title in the form of "CryptPad - {application}' where the application is the name of the application.

For example, the `/slides` application becomes `CryptPad - Markdown Slides` (took from the website).

The applications modified are the ones visible from the front page of the main CryptPad instance. Namely, Rich Text, Sheet, Markdown Slides, Kanban, Code, Diagram and Markdown Slides.

Furthermore, I included a script, written in Javascript, that can be modified to include other applications or to change the format of the title. Lastly, the script skips all `inner.html` files that have a title tag.