### PR TITLE
OO disallow " (copy)" from being added to files used with template

### DIFF
--- a/www/common/onlyoffice/inner.js
+++ b/www/common/onlyoffice/inner.js
@@ -235,13 +235,14 @@ define([
 
 
         var getFileType = function () {
-            var type = common.getMetadataMgr().getPrivateData().ooType;
+            var priv = common.getMetadataMgr().getPrivateData();
+            var type = priv.ooType;
             var title = common.getMetadataMgr().getMetadataLazy().title;
             if (APP.downloadType) {
                 type = APP.downloadType;
                 title = "download";
             }
-            if(title === "" && APP.startWithTemplate) {
+            if(title === "" && APP.startWithTemplate && priv.fromFileData) {
                 var metadata = APP.startWithTemplate.content.metadata;
                 var copyTitle = Messages._getKey('copy_title', [metadata.title || metadata.defaultTitle]);
                 common.getMetadataMgr().updateTitle(copyTitle);


### PR DESCRIPTION
Closes #1177

Pull Request #1067 added " (copy)" to copied OnlyOffice files. But, it made a mistake in the sense that it added it to all files that use a template. (copied files use template internally).

This pull request allows users to create a file using a template without " (copy)" being added.