### PR TITLE
Localize online status in generated account report

### DIFF
--- a/www/admin/inner.js
+++ b/www/admin/inner.js
@@ -398,7 +398,7 @@ define([
         row(Messages.admin_lastPinTime, maybeDate(data.latest));
 
         // currently online
-        row(Messages.admin_currentlyOnline, data.currentlyOnline);
+        row(Messages.admin_currentlyOnline, localizeState(data.currentlyOnline));
 
         // plan name
         row(Messages.admin_planName, data.plan || Messages.ui_none);


### PR DESCRIPTION
I would like to suggest a small change to localize the online status (true or false) in generated account reports. See the following example showing the German translation.

Before:
![grafik](https://github.com/cryptpad/cryptpad/assets/2790261/237071dd-dacb-4c26-89b3-c277991ef112)

After:
![grafik](https://github.com/cryptpad/cryptpad/assets/2790261/c8e65ae5-35d1-4709-85f3-77e81491bf37)