### PR TITLE
Update .gitignore: Add package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ block/
 logs/
 privileged.conf
 config/config.js
+package-lock.json


### PR DESCRIPTION
Since we run npm install during installation [0], we need to add package-lock.json to .gitignore.

[0] https://docs.cryptpad.org/en/admin_guide/installation.html