### PR TITLE
Feature: Add a description field for calendar events

### DIFF
--- a/www/calendar/app-calendar.less
+++ b/www/calendar/app-calendar.less
@@ -197,7 +197,9 @@
                     background-color: @cp_dropdown-bg-hover;
                 }
                 .tui-full-calendar-content {
-                    white-space: nowrap;
+                    &:not(textarea) {
+                        white-space: nowrap;
+                    }
                     overflow: hidden;
                     text-overflow: ellipsis;
                     font: @colortheme_app-font;

--- a/www/calendar/app-calendar.less
+++ b/www/calendar/app-calendar.less
@@ -209,8 +209,12 @@
         .tui-full-calendar-section-date-dash {
             height: auto;
         }
-        .tui-full-calendar-section-title, .tui-full-calendar-section-location {
+        .tui-full-calendar-section-title, .tui-full-calendar-section-location, .tui-full-calendar-section-description {
             width: 100%;
+        }
+        .tui-full-calendar-section-description textarea {
+            width: 100%;
+            height: 200px;
         }
         .tui-full-calendar-dropdown-menu {
             top: 38px;

--- a/www/calendar/app-calendar.less
+++ b/www/calendar/app-calendar.less
@@ -211,10 +211,10 @@
         .tui-full-calendar-section-date-dash {
             height: auto;
         }
-        .tui-full-calendar-section-title, .tui-full-calendar-section-location, .tui-full-calendar-section-description {
+        .tui-full-calendar-section-title, .tui-full-calendar-section-location, .tui-full-calendar-section-body {
             width: 100%;
         }
-        .tui-full-calendar-section-description textarea {
+        .tui-full-calendar-section-body textarea {
             width: 100%;
             height: 200px;
         }

--- a/www/calendar/app-calendar.less
+++ b/www/calendar/app-calendar.less
@@ -254,6 +254,7 @@
                     font: @colortheme_app-font;
                     font-size: 16px;
                     line-height: initial;
+                    padding-left: 0.3rem;
                     pre {
                         margin: 0;
                         font-family: inherit;

--- a/www/calendar/app-calendar.less
+++ b/www/calendar/app-calendar.less
@@ -197,10 +197,6 @@
                     background-color: @cp_dropdown-bg-hover;
                 }
                 .tui-full-calendar-content {
-                    &:not(textarea) {
-                        white-space: nowrap;
-                        overflow: hidden;
-                    }
                     text-overflow: ellipsis;
                     font: @colortheme_app-font;
                     padding: 0 10px;
@@ -213,10 +209,6 @@
         }
         .tui-full-calendar-section-title, .tui-full-calendar-section-location, .tui-full-calendar-section-body {
             width: 100%;
-        }
-        .tui-full-calendar-section-body textarea {
-            width: 100%;
-            height: 200px;
         }
         .tui-full-calendar-dropdown-menu {
             top: 38px;
@@ -250,6 +242,27 @@
                         margin-left: 5px;
                         border-radius: 2px;
                     }
+                }
+                .CodeMirror {
+                    margin-top: 5px;
+                    background: @cp_forms-bg;
+                    color: @cryptpad_text_col;
+                    border: 1px solid @cp_forms-border;
+                    border-radius: @variables_radius;
+                    width: 100%;
+                    height: 80px;
+                    font: @colortheme_app-font;
+                    font-size: 16px;
+                    line-height: initial;
+                    pre {
+                        margin: 0;
+                        font-family: inherit;
+                        font-size: inherit;
+                        line-height: inherit;
+                    }
+                }
+                .CodeMirror-placeholder {
+                    color: @cp_forms-placeholder;
                 }
             }
         }

--- a/www/calendar/app-calendar.less
+++ b/www/calendar/app-calendar.less
@@ -199,8 +199,8 @@
                 .tui-full-calendar-content {
                     &:not(textarea) {
                         white-space: nowrap;
+                        overflow: hidden;
                     }
-                    overflow: hidden;
                     text-overflow: ellipsis;
                     font: @colortheme_app-font;
                     padding: 0 10px;

--- a/www/calendar/export.js
+++ b/www/calendar/export.js
@@ -104,8 +104,13 @@ define([
                 var end = dt.end;
                 var rrule = getRRule(data);
 
-                var escapeValue = function(str) {
-                    return str.replace(/\n/g, ["\\n"]);
+                var formatDescription = function(str) {
+                    var result = str.replace(/\n/g, ["\\n"]);
+                    // XXX Should use ical.js helper foldline instead ↓
+                    // XXX https://kewisch.github.io/ical.js/api/ICAL.module_helpers.html#.foldline
+                    // In RFC5545: https://www.rfc-editor.org/rfc/rfc5545#section-3.1
+                    result = result.replace(/([^\n]{1,74})/g, '$1\n ');
+                    return result;
                 };
 
                 Array.prototype.push.apply(arr, [
@@ -118,7 +123,7 @@ define([
                     rrule,
                     'SUMMARY:'+ data.title,
                     'LOCATION:'+ data.location,
-                    'DESCRIPTION:' + escapeValue(data.body),
+                    'DESCRIPTION:' + formatDescription(data.body),
                 ].filter(Boolean));
 
                 if (Array.isArray(data.reminders)) {

--- a/www/calendar/export.js
+++ b/www/calendar/export.js
@@ -106,7 +106,7 @@ define([
 
                 var escapeValue = function(str) {
                     return str.replace(/\n/g, ["\\n"]);
-                }
+                };
 
                 Array.prototype.push.apply(arr, [
                     'BEGIN:VEVENT',
@@ -118,7 +118,7 @@ define([
                     rrule,
                     'SUMMARY:'+ data.title,
                     'LOCATION:'+ data.location,
-                    'DESCRIPTION:' + escapeValue(data.description),
+                    'DESCRIPTION:' + escapeValue(data.body),
                 ].filter(Boolean));
 
                 if (Array.isArray(data.reminders)) {
@@ -314,7 +314,7 @@ define([
                 }
 
                 // Store other properties
-                var used = ['dtstart', 'dtend', 'uid', 'summary', 'location', 'dtstamp', 'rrule', 'recurrence-id'];
+                var used = ['dtstart', 'dtend', 'uid', 'summary', 'location', 'description', 'dtstamp', 'rrule', 'recurrence-id'];
                 var hidden = [];
                 ev.getAllProperties().forEach(function (p) {
                     if (used.indexOf(p.name) !== -1) { return; }
@@ -359,7 +359,7 @@ define([
                     category: 'time',
                     title: ev.getFirstPropertyValue('summary'),
                     location: ev.getFirstPropertyValue('location'),
-                    description: ev.getFirstPropertyValue('description'),
+                    body: ev.getFirstPropertyValue('description'),
                     isAllDay: isAllDay,
                     start: start,
                     end: end,

--- a/www/calendar/export.js
+++ b/www/calendar/export.js
@@ -3,8 +3,9 @@
 define([
     '/customize/pages.js',
     '/common/common-util.js',
-    '/calendar/recurrence.js'
-], function (Pages, Util, Rec) {
+    '/calendar/recurrence.js',
+    '/lib/ical.min.js'
+], function (Pages, Util, Rec, ICAL) {
     var module = {};
 
     var getICSDate = function (str) {
@@ -96,42 +97,6 @@ define([
                 return rrule;
             };
 
-            // XXX Below function: from ical.js, should be imported instead.
-            // XXX However, if it's done, it would be better to refactor the
-            // XXX export module to directly use ical.js for exporting ICS.
-            var foldline = function(aLine) {
-                var foldLength = 75;
-                var newLineChar = '\r\n';
-                let result = "";
-                let line = aLine || "", pos = 0, line_length = 0;
-                //pos counts position in line for the UTF-16 presentation
-                //line_length counts the bytes for the UTF-8 presentation
-                while (line.length) {
-                    let cp = line.codePointAt(pos);
-                    if (cp < 128) {
-                        ++line_length;
-                    }
-                    else if (cp < 2048) {
-                        line_length += 2;//needs 2 UTF-8 bytes
-                    }
-                    else if (cp < 65536) {
-                        line_length += 3;
-                    }
-                    else {
-                        line_length += 4; //cp is less than 1114112
-                    }
-                    if (line_length < foldLength + 1) {
-                        pos += cp > 65535 ? 2 : 1;
-                    }
-                    else {
-                        result += newLineChar + " " + line.slice(0, Math.max(0, pos));
-                        line = line.slice(Math.max(0, pos));
-                        pos = line_length = 0;
-                    }
-                }
-                return result.slice(newLineChar.length + 1);
-            };
-
             var addEvent = function (arr, data, recId) {
                 var uid = data.id;
                 var dt = getDT(data);
@@ -142,10 +107,9 @@ define([
                 var formatDescription = function(str) {
                     var componentName = 'DESCRIPTION:';
                     var result = componentName + str.replace(/\n/g, ["\\n"]);
-                    // XXX Should use ical.js helper foldline instead ↓
-                    // XXX https://kewisch.github.io/ical.js/api/ICAL.module_helpers.html#.foldline
+                    var ICAL = window.ICAL;
                     // In RFC5545: https://www.rfc-editor.org/rfc/rfc5545#section-3.1
-                    result = foldline(result);
+                    result = ICAL.helpers.foldline(result);
                     return result;
                 };
 

--- a/www/calendar/export.js
+++ b/www/calendar/export.js
@@ -97,13 +97,16 @@ define([
             };
 
 
-
             var addEvent = function (arr, data, recId) {
                 var uid = data.id;
                 var dt = getDT(data);
                 var start = dt.start;
                 var end = dt.end;
                 var rrule = getRRule(data);
+
+                var escapeValue = function(str) {
+                    return str.replace(/\n/g, ["\\n"]);
+                }
 
                 Array.prototype.push.apply(arr, [
                     'BEGIN:VEVENT',
@@ -115,6 +118,7 @@ define([
                     rrule,
                     'SUMMARY:'+ data.title,
                     'LOCATION:'+ data.location,
+                    'DESCRIPTION:' + escapeValue(data.description),
                 ].filter(Boolean));
 
                 if (Array.isArray(data.reminders)) {
@@ -355,6 +359,7 @@ define([
                     category: 'time',
                     title: ev.getFirstPropertyValue('summary'),
                     location: ev.getFirstPropertyValue('location'),
+                    description: ev.getFirstPropertyValue('description'),
                     isAllDay: isAllDay,
                     start: start,
                     end: end,

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -25,10 +25,17 @@ define([
     '/common/inner/properties.js',
 
     '/common/diffMarked.js',
+    '/common/sframe-common-codemirror.js',
+    'cm/lib/codemirror',
 
+    'cm/addon/display/autorefresh',
+    'cm/addon/display/placeholder',
+    'cm/mode/gfm/gfm',
     '/common/jscolor.js',
     '/components/file-saver/FileSaver.min.js',
     'css!/lib/calendar/tui-calendar.min.css',
+    'css!/components/codemirror/lib/codemirror.css',
+    'css!/components/codemirror/addon/dialog/dialog.css',
     'css!/components/components-font-awesome/css/font-awesome.min.css',
     'css!/components/bootstrap/dist/css/bootstrap.min.css',
     'less!/calendar/app-calendar.less',
@@ -54,7 +61,9 @@ define([
     Rec,
     Flatpickr,
     Share, Access, Properties,
-    diffMk
+    diffMk,
+    SFCodeMirror,
+    CodeMirror
     )
 {
     // XXX New translation keys
@@ -2043,20 +2052,30 @@ APP.recurrenceRule = {
 
         description.value = oldEventBody;
 
+        var block = h('div.tui-full-calendar-popup-section', [
+            description,
+        ]);
+
+        var cm = SFCodeMirror.create("gfm", CodeMirror, description);
+        var editor = APP.editor = cm.editor;
+        editor.setOption('lineNumbers', false);
+        editor.setOption('lineWrapping', true);
+        editor.setOption('styleActiveLine', false);
+        editor.setOption('readOnly', false);
+        editor.setOption('autoRefresh', true);
+        editor.setOption('gutters', []);
+        cm.configureTheme(common, function () {});
+        editor.setValue(oldEventBody);
+
         var updateBody = function(value) {
             APP.eventBody = value;
         };
 
-        var $description = $(description);
-        $description.on('input', function() {
-            updateBody(description.value);
+        editor.on('changes', function() {
+            updateBody(editor.getValue());
         });
 
-        return h('div.tui-full-calendar-popup-section.tui-full-calendar-vlayout-area', [
-            h('div.tui-full-calendar-popup-section-item.tui-full-calendar-section-body', [
-                description,
-            ]),
-        ]);
+        return block;
     };
 
     var createToolbar = function () {

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -106,7 +106,7 @@ define([
     };
     var newEvent = function (event, cb) {
         var reminders = APP.notificationsEntries;
-        var description = APP.description;
+        var eventBody = APP.description;
 
         var startDate = event.start._date;
         var endDate = event.end._date;
@@ -121,7 +121,7 @@ define([
             isAllDay: event.isAllDay,
             end: +endDate,
             reminders: reminders,
-            description: description,
+            body: eventBody,
             recurrenceRule: event.recurrenceRule
         };
 
@@ -1039,8 +1039,8 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
                     changes.recurrenceRule = rec;
                 }
 
-                var body = APP.body;
-                changes.body = body;
+                var eventBody = APP.eventBody;
+                changes.body = eventBody;
             }
 
 
@@ -2030,31 +2030,31 @@ APP.recurrenceRule = {
         var calId = ev.selectedCal.id;
         var id = (ev.id && ev.id.split('|')[0]) || undefined;
         var _ev = APP.calendar.getSchedule(ev.id, calId);
-        var oldBody = _ev && _ev.raw && _ev.raw.body;
-        if (!oldBody) {
-            oldBody = Util.find(APP.calendars, [calId, 'content', 'content', id, 'body']) || "";
+        var oldEventBody = _ev && _ev.raw && _ev.raw.body;
+        if (!oldEventBody) {
+            oldEventBody = Util.find(APP.calendars, [calId, 'content', 'content', id, 'body']) || "";
         }
 
-        APP.body = oldBody;
-        var body = h('textarea.tui-full-calendar-content', {
+        APP.eventBody = oldEventBody;
+        var description = h('textarea.tui-full-calendar-content', {
             placeholder: Messages.calendar_desc,
             id: 'tui-full-calendar-body',
         });
 
-        body.value = oldBody;
+        description.value = oldEventBody;
 
         var updateBody = function(value) {
-            APP.body = value;
+            APP.eventBody = value;
         };
 
-        var $body = $(body);
-        $body.on('input', function() {
-            updateBody(body.value);
+        var $description = $(description);
+        $description.on('input', function() {
+            updateBody(description.value);
         });
 
         return h('div.tui-full-calendar-popup-section.tui-full-calendar-vlayout-area', [
             h('div.tui-full-calendar-popup-section-item.tui-full-calendar-section-body', [
-                body,
+                description,
             ]),
         ]);
     };

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -115,7 +115,7 @@ define([
     };
     var newEvent = function (event, cb) {
         var reminders = APP.notificationsEntries;
-        var eventBody = APP.description;
+        var eventBody = APP.eventBody;
 
         var startDate = event.start._date;
         var endDate = event.end._date;

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -409,7 +409,7 @@ define([
         },
         popupDetailBody: function(schedule) {
             var str = schedule.body;
-            delete APP.body;
+            delete APP.eventBody;
             return Messages._getKey('calendar_description', ['<br />', diffMk.render(str, true)]);
         },
         popupIsAllDay: function() { return Messages.calendar_allDay; },

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -57,8 +57,12 @@ define([
     diffMk
     )
 {
+    // XXX New translation keys
     Messages.calendar_rec_change_first = "You moved the first repeating event to different calendar. You can only apply this change to all repeated events."; // XXX New translation key
     Messages.calendar_rec_change = "You moved a repeating event to different calendar. You can only apply this change to this event or all repeated events."; // XXX New translation key
+    Messages.calendar_desc = "Description"; // XXX maybe rename in `description`?
+    Messages.calendar_description = "Description:{0}{1}"; // XXX
+
     var SaveAs = window.saveAs;
     var APP = window.APP = {
         calendars: {}
@@ -397,7 +401,7 @@ define([
         popupDetailBody: function(schedule) {
             var str = schedule.body;
             delete APP.body;
-            return 'Description:<br />' + diffMk.render(str,true);
+            return Messages._getKey('calendar_description', ['<br />', diffMk.render(str, true)]);
         },
         popupIsAllDay: function() { return Messages.calendar_allDay; },
         titlePlaceholder: function() { return Messages.calendar_title; },
@@ -2034,7 +2038,7 @@ APP.recurrenceRule = {
 
         APP.body = oldBody;
         var body = h('textarea.tui-full-calendar-content', {
-            placeholder: 'Description', // TODO: replace with Message.calendar_description
+            placeholder: Messages.calendar_desc,
             id: 'tui-full-calendar-body',
         });
 

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -2030,7 +2030,7 @@ APP.recurrenceRule = {
         var calId = ev.selectedCal.id;
         var id = (ev.id && ev.id.split('|')[0]) || undefined;
         var _ev = APP.calendar.getSchedule(ev.id, calId);
-        var oldEventBody = _ev && _ev.raw && _ev.raw.body;
+        var oldEventBody = _ev && _ev.body;
         if (!oldEventBody) {
             oldEventBody = Util.find(APP.calendars, [calId, 'content', 'content', id, 'body']) || "";
         }

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -24,6 +24,8 @@ define([
     '/common/inner/access.js',
     '/common/inner/properties.js',
 
+    '/common/diffMarked.js',
+
     '/common/jscolor.js',
     '/components/file-saver/FileSaver.min.js',
     'css!/lib/calendar/tui-calendar.min.css',
@@ -51,7 +53,8 @@ define([
     Export,
     Rec,
     Flatpickr,
-    Share, Access, Properties
+    Share, Access, Properties,
+    diffMk,
     )
 {
     Messages.calendar_rec_change_first = "You moved the first repeating event to different calendar. You can only apply this change to all repeated events."; // XXX New translation key
@@ -392,11 +395,9 @@ define([
             return Messages._getKey('calendar_location', [str]);
         },
         popupDetailBody: function(schedule) {
-            var d = schedule.body;
-            var str = Util.fixHTML(d);
-            str = str.replace(/(?:\r\n|\r|\n)/g, '<br />');
+            var str = schedule.body;
             delete APP.body;
-            return 'Description:<br />' + str;
+            return 'Description:<br />' + diffMk.render(str,true);
         },
         popupIsAllDay: function() { return Messages.calendar_allDay; },
         titlePlaceholder: function() { return Messages.calendar_title; },

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -54,7 +54,7 @@ define([
     Rec,
     Flatpickr,
     Share, Access, Properties,
-    diffMk,
+    diffMk
     )
 {
     Messages.calendar_rec_change_first = "You moved the first repeating event to different calendar. You can only apply this change to all repeated events."; // XXX New translation key

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -115,7 +115,7 @@ define([
     };
     var newEvent = function (event, cb) {
         var reminders = APP.notificationsEntries;
-        var eventBody = APP.eventBody;
+        var eventBody = APP.eventBody || "";
 
         var startDate = event.start._date;
         var endDate = event.end._date;
@@ -1048,8 +1048,10 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
                     changes.recurrenceRule = rec;
                 }
 
-                var eventBody = APP.eventBody;
-                changes.body = eventBody;
+                var eventBody = APP.eventBody || "";
+                if (eventBody !== old.body) {
+                    changes.body = eventBody;
+                }
             }
 
 

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -285,7 +285,7 @@ define([
                 var obj = data.content[uid];
                 obj.title = obj.title || "";
                 obj.location = obj.location || "";
-                obj.description = obj.description || "";
+                obj.body = obj.body || "";
                 if (obj.isAllDay && obj.startDay) { obj.start = +Flatpickr.parseDate((obj.startDay)); }
                 if (obj.isAllDay && obj.endDay) {
                     var endDate = Flatpickr.parseDate(obj.endDay);
@@ -390,6 +390,13 @@ define([
             }
 
             return Messages._getKey('calendar_location', [str]);
+        },
+        popupDetailBody: function(schedule) {
+            var d = schedule.body;
+            var str = Util.fixHTML(d);
+            str = str.replace(/(?:\r\n|\r|\n)/g, '<br />');
+            delete APP.body;
+            return 'Description:<br />' + str;
         },
         popupIsAllDay: function() { return Messages.calendar_allDay; },
         titlePlaceholder: function() { return Messages.calendar_title; },
@@ -1027,8 +1034,8 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
                     changes.recurrenceRule = rec;
                 }
 
-                var description = APP.description;
-                changes.description = description;
+                var body = APP.body;
+                changes.body = body;
             }
 
 
@@ -2013,37 +2020,37 @@ APP.recurrenceRule = {
         ]);
     };
 
-    var getDescriptionInput = function() {
+    var getBodyInput = function() {
         var ev = APP.editModalData;
         var calId = ev.selectedCal.id;
         // DEFAULT HERE [10] ==> 10 minutes before the event
         var id = (ev.id && ev.id.split('|')[0]) || undefined;
         var _ev = APP.calendar.getSchedule(ev.id, calId);
-        var oldDescription = _ev && _ev.raw && _ev.raw.description;
-        if (!oldDescription) {
-            oldDescription = Util.find(APP.calendars, [calId, 'content', 'content', id, 'description']) || "";
+        var oldBody = _ev && _ev.raw && _ev.raw.body;
+        if (!oldBody) {
+            oldBody = Util.find(APP.calendars, [calId, 'content', 'content', id, 'body']) || "";
         }
 
-        APP.description = oldDescription;
-        var description = h('textarea.tui-full-calendar-content', {
+        APP.body = oldBody;
+        var body = h('textarea.tui-full-calendar-content', {
             placeholder: 'Description', // TODO: replace with Message.calendar_description
-            id: 'tui-full-calendar-description',
+            id: 'tui-full-calendar-body',
         });
 
-        description.value = oldDescription;
+        body.value = oldBody;
 
-        var updateDescription = function(value) {
-            APP.description = value;
+        var updateBody = function(value) {
+            APP.body = value;
         };
 
-        var $description = $(description);
-        $description.on('input', function() {
-            updateDescription(description.value);
+        var $body = $(body);
+        $body.on('input', function() {
+            updateBody(body.value);
         });
 
         return h('div.tui-full-calendar-popup-section.tui-full-calendar-vlayout-area', [
-            h('div.tui-full-calendar-popup-section-item.tui-full-calendar-section-description', [
-                description,
+            h('div.tui-full-calendar-popup-section-item.tui-full-calendar-section-body', [
+                body,
             ]),
         ]);
     };
@@ -2158,8 +2165,8 @@ APP.recurrenceRule = {
             var div = getNotificationDropdown();
             $button.before(div);
 
-            var descriptionInput = getDescriptionInput();
-            $startDate.parent().parent().before(descriptionInput);
+            var bodyInput = getBodyInput();
+            $startDate.parent().parent().before(bodyInput);
 
             // Use Flatpickr with or without time depending on allday checkbox
             var $cbox = $el.find('#tui-full-calendar-schedule-allday');

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -2028,7 +2028,6 @@ APP.recurrenceRule = {
     var getBodyInput = function() {
         var ev = APP.editModalData;
         var calId = ev.selectedCal.id;
-        // DEFAULT HERE [10] ==> 10 minutes before the event
         var id = (ev.id && ev.id.split('|')[0]) || undefined;
         var _ev = APP.calendar.getSchedule(ev.id, calId);
         var oldBody = _ev && _ev.raw && _ev.raw.body;


### PR DESCRIPTION
- Add a description field when creating and editing an event as per #1171 
  - This field supports markdown information to format the description.
- Integration in the detailed popup view of [tui.calendar](https://github.com/nhn/tui.calendar).
- Support for plaintext/markdown export
  - html export is not supported yet (https://www.rfc-editor.org/rfc/rfc5545#section-3.2.1)

Note: Two new descriptions keys : `calendar_desc` and `calendar_description` are to be added upon version release.