### PR TITLE
Calendar: handling the move of repeating events from a calendar to another

### DIFF
--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -990,7 +990,7 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
                     console.error(err);
                     return void UI.warn(err);
                 }
-                //cal.createSchedules([schedule]); XXX Remove these occurrence elsewhere
+                //cal.createSchedules([schedule]); XXX Remove these occurrences elsewhere
             });
         });
         cal.on('beforeUpdateSchedule', function(event) {

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -54,7 +54,8 @@ define([
     Share, Access, Properties
     )
 {
-    Messages.calendar_rec_change_first = "You moved the first recurring event to different calendar. You can only apply this change to all repeated events."; // XXX New translation key
+    Messages.calendar_rec_change_first = "You moved the first repeating event to different calendar. You can only apply this change to all repeated events."; // XXX New translation key
+    Messages.calendar_rec_change = "You moved a repeating event to different calendar. You can only apply this change to this event or all repeated events."; // XXX New translation key
     var SaveAs = window.saveAs;
     var APP = window.APP = {
         calendars: {}
@@ -1173,11 +1174,15 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
             };
             recurrenceWarn();
             var changeCalendarWarn = function() {
-                if (moveCalendar && wasRecurrent && isOrigin) {
+                if (moveCalendar && wasRecurrent) {
                     // Don't change only the first event of a recurring event
                     $warn.show();
                     $p.hide();
-                    return $warn.text(Messages.calendar_rec_change_first);
+                    if (isOrigin) {
+                        return $warn.text(Messages.calendar_rec_change_first);
+                    } else {
+                        return $warn.text(Messages.calendar_rec_change);
+                    }
                 } else {
                     return null;
                 }

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -1008,6 +1008,7 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
 
             var isOrigin = id === old.id;
             var wasRecurrent = Boolean(originalEvent.recurrenceRule);
+            var moveCalendar = Boolean(changes.calendarId);
 
             if (event.calendar) { // Don't update reminders and recurrence with drag&drop event
                 var oldReminders = ev.raw.reminders || originalEvent.reminders;
@@ -1046,7 +1047,7 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
                 }
 
 
-                if (isOneTime && ev.recurrenceRule && changes.calendarId) {
+                if (isOneTime && wasRecurrent && moveCalendar) {
                     // Copy the event with applied changes
                     var copyEvent = ev;
                     for (let key in changes) {
@@ -1103,7 +1104,7 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
 
             var list = ['one','from','all'];
             if (isOrigin) { list = ['one', 'all']; }
-            if (changes.calendarId) {
+            if (moveCalendar) {
                 if (isOrigin) {
                     // Changing calendar on Origin can only be done for all
                     list = ['all'];
@@ -1172,12 +1173,10 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
             };
             recurrenceWarn();
             var changeCalendarWarn = function() {
-                if (changes.calendarId && evOrig.recurrenceRule && isOrigin) {
+                if (moveCalendar && wasRecurrent && isOrigin) {
                     // Don't change only the first event of a recurring event
                     $warn.show();
                     $p.hide();
-                    console.log($radio.find('input[id="cp.calendar-rec-edit-one"]'));
-                    $radio.find('input[id="cp-calendar-rec-edit-one"]').disabled = true;
                     return $warn.text(Messages.calendar_rec_change_first);
                 } else {
                     return null;

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -1034,7 +1034,7 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
                     end: raw.end || ev.end,
                     isOrigin: isOrigin
                 };
-                var isOneTime = APP.editType == 'one';
+                var isOneTime = APP.editType === 'one';
                 if (['one', 'from'].includes(APP.editType)) {
                     if (changes.start) {
                         changes.start = diffDate(raw.start || ev.start, changes.start);

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -1070,10 +1070,24 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
                             }
                         });
                     } else {
-                        // Modifying the first event
-                        // XXX Not implemented yet
-                        console.error("Not implemented");
-                        return void UI.warn("Not implemented");
+                        var nextEvent = Rec.getSecondOccurrence(old);
+                        changes = {}; // Changes have already been applied to the clone
+                        changes.start = nextEvent.start;
+                        changes.end = nextEvent.end;
+                        delete changes.calendarId;
+
+                        updateEvent({
+                            ev: old,
+                            changes: changes,
+                            type: {
+                                which: 'all'
+                            }
+                        }, function(err) {
+                            if (err) {
+                                console.error(err);
+                                return void UI.warn(err);
+                            }
+                        });
                     }
                 } else {
                     old.id = id;

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -1046,9 +1046,13 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
 
 
                 if (isOneTime && ev.recurrenceRule && changes.calendarId) {
+                    // Copy the event with applied changes
                     var copyEvent = ev;
+                    for (let key in changes) {
+                        copyEvent[key] = changes[key];
+                    }
                     copyEvent.recurrenceRule = "";
-                    copyEvent.calendarId = changes.calendarId;
+
                     newEvent(copyEvent, function(err) {
                         if (err) {
                             console.error(err);
@@ -1057,6 +1061,8 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
                     });
 
                     if (!isOrigin) {
+                        // If it's not the first event, then simply remove the
+                        // original occurrence
                         deleteEvent(old, function(err) {
                             if (err) {
                                 console.error(err);

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -95,7 +95,25 @@ define([
             cb(null, obj);
         });
     };
-    var newEvent = function (data, cb) {
+    var newEvent = function (event, cb) {
+        var reminders = APP.notificationsEntries;
+
+        var startDate = event.start._date;
+        var endDate = event.end._date;
+
+        var data = {
+            id: Util.uid(),
+            calendarId: event.calendarId,
+            title: event.title,
+            category: "time",
+            location: event.location,
+            start: +startDate,
+            isAllDay: event.isAllDay,
+            end: +endDate,
+            reminders: reminders,
+            recurrenceRule: event.recurrenceRule
+        };
+
         APP.module.execCommand('CREATE_EVENT', data, function (obj) {
             if (obj && obj.error) { return void cb(obj.error); }
             cb(null, obj);
@@ -964,30 +982,13 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
         makeLeftside(cal, $(leftside));
 
         cal.on('beforeCreateSchedule', function(event) {
-            var reminders = APP.notificationsEntries;
-
-            var startDate = event.start._date;
-            var endDate = event.end._date;
-
-            var schedule = {
-                id: Util.uid(),
-                calendarId: event.calendarId,
-                title: event.title,
-                category: "time",
-                location: event.location,
-                start: +startDate,
-                isAllDay: event.isAllDay,
-                end: +endDate,
-                reminders: reminders,
-                recurrenceRule: APP.recurrenceRule
-            };
-
-            newEvent(schedule, function (err) {
+            event.recurrenceRule = APP.recurrenceRule; // XXX Not sure about the consistency of data structures
+            newEvent(event, function (err) {
                 if (err) {
                     console.error(err);
                     return void UI.warn(err);
                 }
-                cal.createSchedules([schedule]);
+                //cal.createSchedules([schedule]); XXX Remove these occurrence elsewhere
             });
         });
         cal.on('beforeUpdateSchedule', function(event) {

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -1189,6 +1189,7 @@ ICS ==> create a new event with the same UID and a RECURRENCE-ID field (with a v
             };
             changeCalendarWarn();
             $radio.find('input[type="radio"]').on('change', recurrenceWarn);
+            $radio.find('input[type="radio"]').on('change', changeCalendarWarn);
         });
         cal.on('beforeDeleteSchedule', function(event) {
             deleteEvent(event.schedule, function (err) {

--- a/www/calendar/recurrence.js
+++ b/www/calendar/recurrence.js
@@ -773,14 +773,6 @@ define([
 
         return all;
     };
-    Rec.getSecondOccurrence = function (ev) {
-        if (!ev.recurrenceRule) { return null; }
-        var d = new Date(ev.start);
-        d.setDate(15); // Make sure we won't skip a month if the event starts on day > 28
-        var secondOccurrence = Rec.getRecurring([Rec.getMonthId(d)], [ev]);
-
-        return secondOccurrence[0];
-    };
 
     Rec.diffDate = function (oldTime, newTime) {
         var n = new Date(newTime);

--- a/www/calendar/recurrence.js
+++ b/www/calendar/recurrence.js
@@ -773,6 +773,14 @@ define([
 
         return all;
     };
+    Rec.getSecondOccurrence = function (ev) {
+        if (!ev.recurrenceRule) { return null; }
+        var d = new Date(ev.start);
+        d.setDate(15); // Make sure we won't skip a month if the event starts on day > 28
+        var secondOccurrence = Rec.getRecurring([Rec.getMonthId(d)], [ev]);
+
+        return secondOccurrence[0];
+    };
 
     Rec.diffDate = function (oldTime, newTime) {
         var n = new Date(newTime);


### PR DESCRIPTION
This pull request proposes the following changes to fix the issue #1275:
1. In the case where a single instance of a repeating event is moved from a calendar to another it is copied in the target calendar as a single event and added as an exception of the recurrence rules in the source calendar.
2. Due to the current implementation of recurring event, it is not possible to perform the two cases described hereunder. Henceforth, these cases have been disabled in the UI.
    - Only move the first element of a repeating event (which contains the recurrence rules) from a calendar to another.
    - For the same reason, we cannot move a repeating event to another calendar from a certain date.
4. Adding explanation messages in forms of warnings as to why these options don't appear in the confirmation popup.