### PR TITLE
Reformat `www/calendar/export.js`

### DIFF
--- a/www/calendar/export.js
+++ b/www/calendar/export.js
@@ -108,9 +108,8 @@ define([
                 var formatDescription = function(str) {
                     var componentName = 'DESCRIPTION:';
                     var result = componentName + str.replace(/\n/g, ["\\n"]);
-                    var ICAL = window.ICAL;
                     // In RFC5545: https://www.rfc-editor.org/rfc/rfc5545#section-3.1
-                    result = ICAL.helpers.foldline(result);
+                    result = window.ICAL.helpers.foldline(result);
                     return result;
                 };
 
@@ -263,155 +262,153 @@ define([
     };
 
     module.import = function (content, id, cb) {
-        require(['/lib/ical.min.js'], function () {
-            var ICAL = window.ICAL;
-            var res = {};
+        var ICAL = window.ICAL;
+        var res = {};
 
-            var vcalendar;
-            try {
-                var jcalData = ICAL.parse(content);
-                vcalendar = new ICAL.Component(jcalData);
-            } catch (e) {
-                console.error(e);
-                return void cb(e);
+        var vcalendar;
+        try {
+            var jcalData = ICAL.parse(content);
+            vcalendar = new ICAL.Component(jcalData);
+        } catch (e) {
+            console.error(e);
+            return void cb(e);
+        }
+
+        //var method = vcalendar.getFirstPropertyValue('method');
+        //if (method !== "PUBLISH") { return void cb('NOT_SUPPORTED'); }
+
+        // Add all timezones in iCalendar object to TimezoneService
+        // if they are not already registered.
+            var timezones = vcalendar.getAllSubcomponents("vtimezone");
+        timezones.forEach(function (timezone) {
+            if (!(ICAL.TimezoneService.has(timezone.getFirstPropertyValue("tzid")))) {
+                ICAL.TimezoneService.register(timezone);
+            }
+        });
+
+        var events = vcalendar.getAllSubcomponents('vevent');
+        events.forEach(function (ev) {
+            var uid = ev.getFirstPropertyValue('uid');
+            if (!uid) { return; }
+
+            // Get start and end time
+            var isAllDay = false;
+            var start = ev.getFirstPropertyValue('dtstart');
+            var end = ev.getFirstPropertyValue('dtend');
+            var duration = ev.getFirstPropertyValue('duration');
+            if (!end && !duration) {
+                if (start.isDate) {
+                    end = start.clone();
+                    end.adjust(1); // Add one day
+                } else {
+                    end = start.clone();
+                }
+            } else if (!end) {
+                end = start.clone();
+                end.addDuration(duration);
+            }
+            if (start.isDate && end.isDate) {
+                isAllDay = true;
+                start = String(start);
+                end.adjust(-1); // Substract one day
+                end = String(end);
+            } else {
+                start = +start.toJSDate();
+                end = +end.toJSDate();
             }
 
-            //var method = vcalendar.getFirstPropertyValue('method');
-            //if (method !== "PUBLISH") { return void cb('NOT_SUPPORTED'); }
-
-            // Add all timezones in iCalendar object to TimezoneService
-            // if they are not already registered.
-            var timezones = vcalendar.getAllSubcomponents("vtimezone");
-            timezones.forEach(function (timezone) {
-                if (!(ICAL.TimezoneService.has(timezone.getFirstPropertyValue("tzid")))) {
-                    ICAL.TimezoneService.register(timezone);
-                }
+            // Store other properties
+            var used = ['dtstart', 'dtend', 'uid', 'summary', 'location', 'description', 'dtstamp', 'rrule', 'recurrence-id'];
+            var hidden = [];
+            ev.getAllProperties().forEach(function (p) {
+                if (used.indexOf(p.name) !== -1) { return; }
+                // This is an unused property
+                hidden.push(p.toICALString());
             });
 
-            var events = vcalendar.getAllSubcomponents('vevent');
-            events.forEach(function (ev) {
-                var uid = ev.getFirstPropertyValue('uid');
-                if (!uid) { return; }
-
-                // Get start and end time
-                var isAllDay = false;
-                var start = ev.getFirstPropertyValue('dtstart');
-                var end = ev.getFirstPropertyValue('dtend');
-                var duration = ev.getFirstPropertyValue('duration');
-                if (!end && !duration) {
-                    if (start.isDate) {
-                        end = start.clone();
-                        end.adjust(1); // Add one day
-                    } else {
-                        end = start.clone();
-                    }
-                } else if (!end) {
-                    end = start.clone();
-                    end.addDuration(duration);
+            // Get reminders
+            var reminders = [];
+            ev.getAllSubcomponents('valarm').forEach(function (al) {
+                var action = al.getFirstPropertyValue('action');
+                if (action !== 'DISPLAY') {
+                    // Email notification: keep it in "hidden" and create a cryptpad notification
+                    hidden.push(al.toString());
                 }
-                if (start.isDate && end.isDate) {
-                    isAllDay = true;
-                    start = String(start);
-                    end.adjust(-1); // Substract one day
-                    end = String(end);
-                } else {
-                    start = +start.toJSDate();
-                    end = +end.toJSDate();
-                }
+                var trigger = al.getFirstPropertyValue('trigger');
+                var minutes = trigger && trigger.toSeconds ? (-trigger.toSeconds() / 60) : 0;
+                if (reminders.indexOf(minutes) === -1) { reminders.push(minutes); }
+            });
 
-                // Store other properties
-                var used = ['dtstart', 'dtend', 'uid', 'summary', 'location', 'description', 'dtstamp', 'rrule', 'recurrence-id'];
-                var hidden = [];
-                ev.getAllProperties().forEach(function (p) {
-                    if (used.indexOf(p.name) !== -1) { return; }
-                    // This is an unused property
-                    hidden.push(p.toICALString());
+            // Get recurrence rule
+            var rrule = ev.getFirstPropertyValue('rrule');
+            var rec;
+            if (rrule && rrule.freq) {
+                rec = {};
+                rec.freq = rrule.freq.toLowerCase();
+                if (rrule.interval) { rec.interval = rrule.interval; }
+                if (rrule.count) { rec.count = rrule.count; }
+                if (Object.keys(rrule).includes('wkst')) { rec.wkst = (rrule.wkst + 6) % 7; }
+                if (rrule.until) { rec.until = +new Date(rrule.until); }
+                Object.keys(rrule.parts || {}).forEach(function (k) {
+                    rec.by = rec.by || {};
+                    var _k = k.toLowerCase().slice(2); // "BYDAY" ==> "day"
+                    rec.by[_k] = rrule.parts[k];
                 });
+            }
 
-                // Get reminders
-                var reminders = [];
-                ev.getAllSubcomponents('valarm').forEach(function (al) {
-                    var action = al.getFirstPropertyValue('action');
-                    if (action !== 'DISPLAY') {
-                        // Email notification: keep it in "hidden" and create a cryptpad notification
-                        hidden.push(al.toString());
-                    }
-                    var trigger = al.getFirstPropertyValue('trigger');
-                    var minutes = trigger && trigger.toSeconds ? (-trigger.toSeconds() / 60) : 0;
-                    if (reminders.indexOf(minutes) === -1) { reminders.push(minutes); }
+            // Create event
+            var obj = {
+                calendarId: id,
+                id: uid,
+                category: 'time',
+                title: ev.getFirstPropertyValue('summary'),
+                location: ev.getFirstPropertyValue('location'),
+                body: ev.getFirstPropertyValue('description'),
+                isAllDay: isAllDay,
+                start: start,
+                end: end,
+                reminders: reminders,
+                cp_hidden: hidden,
+            };
+            if (rec) { obj.recurrenceRule = rec; }
+
+            if (!hidden.length) { delete obj.cp_hidden; }
+            if (!reminders.length) { delete obj.reminders; }
+
+            var recId = ev.getFirstPropertyValue('recurrence-id');
+            if (recId) {
+                setTimeout(function () {
+                    if (!res[uid]) { return; }
+                    var old = res[uid];
+                    var time = +new Date(recId);
+                    var diff = {};
+                    var from = {};
+                    Object.keys(obj).forEach(function (k) {
+                        if (JSON.stringify(old[k]) === JSON.stringify(obj[k])) { return; }
+                        if (['start','end'].includes(k)) {
+                            diff[k] = Rec.diffDate(old[k], obj[k]);
+                            return;
+                        }
+                        if (k === "recurrenceRule") {
+                            from[k] = obj[k];
+                            return;
+                        }
+                        diff[k] = obj[k];
+                    });
+                    old.recUpdate = old.recUpdate || {one:{},from:{}};
+                    if (Object.keys(from).length) { old.recUpdate.from[time] = from; }
+                    if (Object.keys(diff).length) { old.recUpdate.one[time] = diff; }
                 });
+                return;
+            }
 
-                // Get recurrence rule
-                var rrule = ev.getFirstPropertyValue('rrule');
-                var rec;
-                if (rrule && rrule.freq) {
-                    rec = {};
-                    rec.freq = rrule.freq.toLowerCase();
-                    if (rrule.interval) { rec.interval = rrule.interval; }
-                    if (rrule.count) { rec.count = rrule.count; }
-                    if (Object.keys(rrule).includes('wkst')) { rec.wkst = (rrule.wkst + 6) % 7; }
-                    if (rrule.until) { rec.until = +new Date(rrule.until); }
-                    Object.keys(rrule.parts || {}).forEach(function (k) {
-                        rec.by = rec.by || {};
-                        var _k = k.toLowerCase().slice(2); // "BYDAY" ==> "day"
-                        rec.by[_k] = rrule.parts[k];
-                    });
-                }
+            res[uid] = obj;
+        });
 
-                // Create event
-                var obj = {
-                    calendarId: id,
-                    id: uid,
-                    category: 'time',
-                    title: ev.getFirstPropertyValue('summary'),
-                    location: ev.getFirstPropertyValue('location'),
-                    body: ev.getFirstPropertyValue('description'),
-                    isAllDay: isAllDay,
-                    start: start,
-                    end: end,
-                    reminders: reminders,
-                    cp_hidden: hidden,
-                };
-                if (rec) { obj.recurrenceRule = rec; }
-
-                if (!hidden.length) { delete obj.cp_hidden; }
-                if (!reminders.length) { delete obj.reminders; }
-
-                var recId = ev.getFirstPropertyValue('recurrence-id');
-                if (recId) {
-                    setTimeout(function () {
-                        if (!res[uid]) { return; }
-                        var old = res[uid];
-                        var time = +new Date(recId);
-                        var diff = {};
-                        var from = {};
-                        Object.keys(obj).forEach(function (k) {
-                            if (JSON.stringify(old[k]) === JSON.stringify(obj[k])) { return; }
-                            if (['start','end'].includes(k)) {
-                                diff[k] = Rec.diffDate(old[k], obj[k]);
-                                return;
-                            }
-                            if (k === "recurrenceRule") {
-                                from[k] = obj[k];
-                                return;
-                            }
-                            diff[k] = obj[k];
-                        });
-                        old.recUpdate = old.recUpdate || {one:{},from:{}};
-                        if (Object.keys(from).length) { old.recUpdate.from[time] = from; }
-                        if (Object.keys(diff).length) { old.recUpdate.one[time] = diff; }
-                    });
-                    return;
-                }
-
-                res[uid] = obj;
-            });
-
-            // setTimeout to make sure we call back after the "recurrence-id" setTimeout
-            // are called
-            setTimeout(function () {
-                cb(null, res);
-            });
+        // setTimeout to make sure we call back after the "recurrence-id" setTimeout
+        // are called
+        setTimeout(function () {
+            cb(null, res);
         });
     };
 

--- a/www/calendar/export.js
+++ b/www/calendar/export.js
@@ -4,8 +4,9 @@ define([
     '/customize/pages.js',
     '/common/common-util.js',
     '/calendar/recurrence.js',
+
     '/lib/ical.min.js'
-], function (Pages, Util, Rec, ICAL) {
+], function (Pages, Util, Rec) {
     var module = {};
 
     var getICSDate = function (str) {


### PR DESCRIPTION
This pull request addresses two (related) issues:

- Fix a linter error introduced by #1299 from `ical.min.js` which was not made with requireJS in mind.
- As `ical.min.js` is now loaded on the whole file and not only used by the ics import module, we removed the `require(…)` from it and re-indent the whole block.