### PR TITLE
Fix the error upon importing a template in forms (#1261)

### DIFF
--- a/www/common/cryptpad-common.js
+++ b/www/common/cryptpad-common.js
@@ -924,7 +924,14 @@ define([
             delete meta.cursor;
 
             if (meta.type === "form") {
+                // Keep anonymous and makeAnonymous values from templates
+                var anonymous = parsed.answers.anonymous || false;
+                var makeAnonymous = parsed.answers.makeAnonymous || false;
                 delete parsed.answers;
+                parsed.answers = {
+                    anonymous: anonymous,
+                    makeAnonymous: makeAnonymous
+                };
             }
         }
     };

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -4539,6 +4539,20 @@ define([
             var resultsStr = h('div');
             var $results = $(resultsType);
             var refreshPublic = function () {
+                // Perform sanity check on refresh
+                // (for instance on template import)
+                if (APP.isEditor) {
+                    if (!content.answers || !content.answers.channel || !content.answers.publicKey || !content.answers.validateKey) {
+                        // Don't override other settings (anonymous, makeAnonymous, etc.) from templates
+                        content.answers = content.answers || {};
+                        content.answers.channel = Hash.createChannelId();
+                        content.answers.publicKey = priv.form_public;
+                        content.answers.validateKey = priv.form_answerValidateKey;
+                        content.answers.version = 2;
+                        framework.localChange();
+                    }
+                    checkIntegrity();
+                }
                 $results.empty();
                 var makePublic = h('button.btn.btn-secondary', Messages.form_makePublic);
                 var makePublicDiv = h('div.cp-form-actions', makePublic);

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -4525,7 +4525,7 @@ define([
             content.answers.validateKey = priv.form_answerValidateKey;
             content.answers.version = 2;
             framework.localChange();
-        }
+        };
 
         var makeFormSettings = function () {
             var previewBtn = h('button.btn.btn-primary', [

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -4534,13 +4534,8 @@ define([
                 });
             });
 
-            // Private / public status
-            var resultsType = h('div.cp-form-results-type-container');
-            var resultsStr = h('div');
-            var $results = $(resultsType);
-            var refreshPublic = function () {
-                // Perform sanity check on refresh
-                // (for instance on template import)
+            // Perform a sanity check on refresh (for instance on template imports)
+            var checkAnswersValidity = function() {
                 if (APP.isEditor) {
                     if (!content.answers || !content.answers.channel || !content.answers.publicKey || !content.answers.validateKey) {
                         // Don't override other settings (anonymous, makeAnonymous, etc.) from templates
@@ -4552,6 +4547,13 @@ define([
                         framework.localChange();
                     }
                 }
+            };
+
+            // Private / public status
+            var resultsType = h('div.cp-form-results-type-container');
+            var resultsStr = h('div');
+            var $results = $(resultsType);
+            var refreshPublic = function () {
                 $results.empty();
                 var makePublic = h('button.btn.btn-secondary', Messages.form_makePublic);
                 var makePublicDiv = h('div.cp-form-actions', makePublic);
@@ -4882,6 +4884,7 @@ define([
             };
             refreshColorTheme();
 
+            evOnChange.reg(checkAnswersValidity);
             evOnChange.reg(refreshPublic);
             evOnChange.reg(refreshPrivacy);
             evOnChange.reg(refreshAnon);

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -4514,6 +4514,19 @@ define([
             $('.cp-toolbar-icon-snapshots').hide();
         }
 
+        var initializeAnswers = function() {
+            // Initialize the answers channel if it doesn't exist yet
+            if (!APP.isEditor) { return; }
+            if (content.answers && content.answers.channel && content.answers.publicKey && content.answers.validateKey) { return; }
+            // Don't override other settings (anonymous, makeAnonymous, etc.) from templates
+            content.answers = content.answers || {};
+            content.answers.channel = Hash.createChannelId();
+            content.answers.publicKey = priv.form_public;
+            content.answers.validateKey = priv.form_answerValidateKey;
+            content.answers.version = 2;
+            framework.localChange();
+        }
+
         var makeFormSettings = function () {
             var previewBtn = h('button.btn.btn-primary', [
                 h('i.fa.fa-eye'),
@@ -4533,21 +4546,6 @@ define([
                     UI.warn(Messages.error);
                 });
             });
-
-            // Perform a sanity check on refresh (for instance on template imports)
-            var checkAnswersValidity = function() {
-                if (APP.isEditor) {
-                    if (!content.answers || !content.answers.channel || !content.answers.publicKey || !content.answers.validateKey) {
-                        // Don't override other settings (anonymous, makeAnonymous, etc.) from templates
-                        content.answers = content.answers || {};
-                        content.answers.channel = Hash.createChannelId();
-                        content.answers.publicKey = priv.form_public;
-                        content.answers.validateKey = priv.form_answerValidateKey;
-                        content.answers.version = 2;
-                        framework.localChange();
-                    }
-                }
-            };
 
             // Private / public status
             var resultsType = h('div.cp-form-results-type-container');
@@ -4884,7 +4882,7 @@ define([
             };
             refreshColorTheme();
 
-            evOnChange.reg(checkAnswersValidity);
+            evOnChange.reg(initializeAnswers);
             evOnChange.reg(refreshPublic);
             evOnChange.reg(refreshPrivacy);
             evOnChange.reg(refreshAnon);
@@ -5152,15 +5150,7 @@ define([
                     content.order = ["1", "2"];
                     framework.localChange();
                 }
-                if (!content.answers || !content.answers.channel || !content.answers.publicKey || !content.answers.validateKey) {
-                    // Don't override other settings (anonymous, makeAnonymous, etc.) from templates
-                    content.answers = content.answers || {};
-                    content.answers.channel = Hash.createChannelId();
-                    content.answers.publicKey = priv.form_public;
-                    content.answers.validateKey = priv.form_answerValidateKey;
-                    content.answers.version = 2;
-                    framework.localChange();
-                }
+                initializeAnswers();
                 checkIntegrity();
             }
             if (isNew && content.answers && typeof(content.answers.anonymous) === "undefined") {

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -4515,7 +4515,7 @@ define([
         }
 
         var initializeAnswers = function() {
-            // Initialize the answers channel if it doesn't exist yet
+            // Initialize the answers properties if they do not exist yet
             if (!APP.isEditor) { return; }
             if (content.answers && content.answers.channel && content.answers.publicKey && content.answers.validateKey) { return; }
             // Don't override other settings (anonymous, makeAnonymous, etc.) from templates

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -4551,7 +4551,6 @@ define([
                         content.answers.version = 2;
                         framework.localChange();
                     }
-                    checkIntegrity();
                 }
                 $results.empty();
                 var makePublic = h('button.btn.btn-secondary', Messages.form_makePublic);


### PR DESCRIPTION
Fix the bug where importing a template in form raised an error: #1261

While fixing it, set a behaviour upon importing template:
- Now, the settings on allowing anonymous responses and enforcing anonymous responses are stored into the template and override the previous ones.
  - Usecases: creating a template for anonymous poll and a template for registered-only users.