### PR TITLE
Fix a few export-related issues

### DIFF
--- a/www/form/export.js
+++ b/www/form/export.js
@@ -2,7 +2,9 @@ define([
     '/common/common-util.js',
     '/customize/messages.js'
 ], function (Util, Messages) {
-    var Export = {};
+    var Export = {
+        ext: '.json'
+    };
 
     var escapeCSV = function (v) {
         if (!/("|,|\n|;)/.test(v)) {

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -4519,6 +4519,7 @@ define([
             if (!APP.isEditor) { return; }
             if (content.answers && content.answers.channel && content.answers.publicKey && content.answers.validateKey) { return; }
             // Don't override other settings (anonymous, makeAnonymous, etc.) from templates
+            var priv = metadataMgr.getPrivateData();
             content.answers = content.answers || {};
             content.answers.channel = Hash.createChannelId();
             content.answers.publicKey = priv.form_public;

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -4517,9 +4517,9 @@ define([
         var initializeAnswers = function() {
             // Initialize the answers properties if they do not exist yet
             if (!APP.isEditor) { return; }
-            if (content.answers && content.answers.channel && content.answers.publicKey && content.answers.validateKey) { return; }
-            // Don't override other settings (anonymous, makeAnonymous, etc.) from templates
             var priv = metadataMgr.getPrivateData();
+            if (content.answers && content.answers.channel && content.answers.publicKey === priv.form_public && content.answers.validateKey) { return; }
+            // Don't override other settings (anonymous, makeAnonymous, etc.) from templates
             content.answers = content.answers || {};
             content.answers.channel = Hash.createChannelId();
             content.answers.publicKey = priv.form_public;

--- a/www/whiteboard/export.js
+++ b/www/whiteboard/export.js
@@ -30,6 +30,7 @@ define([
             canvas.setWidth(w);
             canvas.setHeight(h);
             canvas.calcOffset();
+            canvas.renderAll();
 
             module.ext = '.png';
             canvas_node.toBlob(cb);

--- a/www/whiteboard/export.js
+++ b/www/whiteboard/export.js
@@ -25,8 +25,9 @@ define([
                     if (c[k].y > h) { h = c[k].y + 1; }
                 });
             });
-            w = Math.min(w, MAX);
-            h = Math.min(h, MAX);
+            // Empty documents are rendered as a 600x600 transparent PNG image
+            w = w === 0 ? 600 : Math.min(w, MAX);
+            h = h === 0 ? 600 : Math.min(h, MAX);
             canvas.setWidth(w);
             canvas.setHeight(h);
             canvas.calcOffset();


### PR DESCRIPTION
This PR tackles multiple issues, namely:
1. #1267: this issues is solved with 51abbb484fadf43e9ce2691b305eede48eb70378, it was an issue with the export module for the whiteboard application which automatically detects the size of the exported image, which is set to be 0×0 in the case of empty whiteboard. This kind of image could not be exported and resulted in a missing file. To sort this out, we decided to set a default size of 600×600 pixels for empty whiteboard to be consistent with the other empty-files export.
2. While solving this, we also noticed that other whiteboard exports (from drive) were transparent PNG files (of the right size however) as described in #1324. This is fixed in 0005b933e98f3f200364bfa1bef79cd7fe94c7a9 and was due to a missing rendering of the canvas.
3. Finally, while checking the behavior of different exports, we noticed that the Form exports were missing their extension, and it was fixed in 38b20e84177057f46292fc52fb5d3d5e14fff02e