### PR TITLE
File icons in drive

### DIFF
--- a/customize.dist/src/less2/include/drive.less
+++ b/customize.dist/src/less2/include/drive.less
@@ -670,7 +670,7 @@
                 .cp-app-drive-element-icon {
                     font-size: 12px !important;
                     float: left !important;
-                    margin: 5px !important;
+                    margin: 4px !important;
                 }
                 .cp-app-drive-element-name-icon {
                     text-align: center !important;
@@ -744,7 +744,6 @@
                     display: inline-block;
                     white-space: nowrap;
                     &:first-child, &.cp-icon {
-                        display: block-inline;
                         min-width: 20px;
                         text-align: center;
                         font-size: 18px;

--- a/customize.dist/src/less2/include/drive.less
+++ b/customize.dist/src/less2/include/drive.less
@@ -54,7 +54,9 @@
                 width: 100%;
                 height: 24px;
                 margin: 0;
-                display: inline-block;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
                 font-size: 14px;
                 //align-items: center;
                 //justify-content: center;
@@ -668,14 +670,14 @@
                     }
                 }
                 .cp-app-drive-element-icon {
-                    font-size: 12px !important;
-                    float: left !important;
-                    margin: 4px !important;
+                    font-size: 0.9rem;
+                    margin: 0;
+                    margin-right: 0.3rem;
                 }
-                .cp-app-drive-element-name-icon {
-                    text-align: center !important;
-                    float: center !important;
-                    max-width: fit-content !important;
+                .cp-app-drive-element-name-text {
+                    overflow: hidden;
+                    white-space: nowrap;
+                    text-overflow: ellipsis;
                 }
 
                 .cp-app-drive-element-state {

--- a/customize.dist/src/less2/include/drive.less
+++ b/customize.dist/src/less2/include/drive.less
@@ -678,7 +678,7 @@
                     max-height: 100px;
                     background: @cp_drive-thumb-bg;
                     & ~ .fa, & ~ .cptools {
-                        display: inline;
+                        display: none;
                         font-size: 17px;
                         position: absolute;
                         top: 3px;
@@ -730,6 +730,7 @@
                     display: inline-block;
                     white-space: nowrap;
                     &:first-child, &.cp-icon {
+                        display: block-inline;
                         min-width: 20px;
                         text-align: center;
                         font-size: 18px;

--- a/customize.dist/src/less2/include/drive.less
+++ b/customize.dist/src/less2/include/drive.less
@@ -634,7 +634,6 @@
             }
         }
         div.cp-app-drive-content-grid {
-
             padding: 1em;
             ul {
                 margin: -(@drive_icon-margin);
@@ -672,13 +671,11 @@
                     font-size: 12px !important;
                     float: left !important;
                     margin: 5px !important;
-                
                 }
                 .cp-app-drive-element-name-icon {
                     text-align: center !important;
                     float: center !important;
                     max-width: fit-content !important;
-                
                 }
 
                 .cp-app-drive-element-state {
@@ -715,7 +712,6 @@
         }
 
         div.cp-app-drive-content-list {
-
             .cp-app-drive-element-icon {
                 display: none !important;
             }
@@ -1047,7 +1043,6 @@
         order: 15;
         margin: 0 1em;
     }
-
 
 }
 

--- a/customize.dist/src/less2/include/drive.less
+++ b/customize.dist/src/less2/include/drive.less
@@ -634,6 +634,7 @@
             }
         }
         div.cp-app-drive-content-grid {
+
             padding: 1em;
             ul {
                 margin: -(@drive_icon-margin);
@@ -667,6 +668,19 @@
                         font-size: 18px;
                     }
                 }
+                .cp-app-drive-element-icon {
+                    font-size: 12px !important;
+                    float: left !important;
+                    margin: 5px !important;
+                
+                }
+                .cp-app-drive-element-name-icon {
+                    text-align: center !important;
+                    float: center !important;
+                    max-width: fit-content !important;
+                
+                }
+
                 .cp-app-drive-element-state {
                     left: 3px;
                 }
@@ -701,6 +715,10 @@
         }
 
         div.cp-app-drive-content-list {
+
+            .cp-app-drive-element-icon {
+                display: none !important;
+            }
             .cp-app-drive-element-grid {
                 display: none;
             }
@@ -1029,6 +1047,7 @@
         order: 15;
         margin: 0 1em;
     }
+
 
 }
 

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -2217,13 +2217,15 @@ define([
             var name = manager.getTitle(element);
 
             // The element with the class '.name' is underlined when the 'li' is hovered
-            var $name = $('<span>', {'class': 'cp-app-drive-element-name'}).text(name);
+            var $name = $(h('span.cp-app-drive-element-name', [
+                h('span.cp-app-drive-element-name-text', name)
+            ]));
             $element.append($name);
             $element.append($state);
             if (APP.mobile()) {
                 $element.append($menu);
             }
-            
+
             if (getViewMode() === 'grid') {
                 $element.attr('title', name);
             }

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -2158,7 +2158,7 @@ define([
         };
         var getIcon = UI.getIcon;
 
-        var addTitle = function (element, $name) {
+        var addTitleIcon = function (element, $name) {
             var icon = getFileIcon(element);
 
             $(icon).addClass('cp-app-drive-element-icon');
@@ -2236,7 +2236,7 @@ define([
                 $element.prepend(img);
                 $(img).addClass('cp-app-drive-element-grid cp-app-drive-element-thumbnail');
                 $(img).attr("draggable", false);
-                addTitle(element, $name);
+                addTitleIcon(element, $name);
             } else {
                 common.displayThumbnail(href || data.roHref, data.channel, data.password, $element, function ($thumb) {
                     // Called only if the thumbnail exists
@@ -2245,7 +2245,7 @@ define([
                     $thumb.addClass('cp-app-drive-element-grid cp-app-drive-element-thumbnail');
                     $thumb.attr("draggable", false);
                     thumbsUrls[element] = $thumb[0].src;
-                    addTitle(element, $name);
+                    addTitleIcon(element, $name);
                 });
             }
 

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -2220,6 +2220,7 @@ define([
                 $element.prepend(img);
                 $(img).addClass('cp-app-drive-element-grid cp-app-drive-element-thumbnail');
                 $(img).attr("draggable", false);
+                addTitle(element, $element, $name)
             }
             else {
                 common.displayThumbnail(href || data.roHref, data.channel, data.password, $element, function ($thumb) {
@@ -2229,6 +2230,8 @@ define([
                     $thumb.addClass('cp-app-drive-element-grid cp-app-drive-element-thumbnail');
                     $thumb.attr("draggable", false);
                     thumbsUrls[element] = $thumb[0].src;
+                    addTitle(element, $element, $name)
+
                 });
             }
 
@@ -2244,6 +2247,15 @@ define([
             }).text(getDate(data.ctime));
             $element.append($type).append($adate).append($cdate);
         };
+
+        var addTitle = function (element, $element, $name) {
+            var icon = getFileIcon(element)
+
+            $(icon).addClass('cp-app-drive-element-icon')
+            $name.addClass('cp-app-drive-element-name-icon')
+            $name.prepend($(icon))
+
+        }
 
         var addFolderData = function (element, key, $span) {
             if (!element || !manager.isFolder(element)) { return; }

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -2150,6 +2150,22 @@ define([
             } */
         };
         var thumbsUrls = {};
+
+        // This is duplicated in cryptpad-common, it should be unified
+        var getFileIcon = function (id) {
+            var data = manager.getFileData(id);
+            return UI.getFileIcon(data);
+        };
+        var getIcon = UI.getIcon;
+
+        var addTitle = function (element, $name) {
+            var icon = getFileIcon(element);
+
+            $(icon).addClass('cp-app-drive-element-icon');
+            $name.addClass('cp-app-drive-element-name-icon');
+            $name.prepend($(icon));
+        };
+
         var addFileData = function (element, $element) {
             if (!manager.isFile(element)) { return; }
 
@@ -2220,9 +2236,8 @@ define([
                 $element.prepend(img);
                 $(img).addClass('cp-app-drive-element-grid cp-app-drive-element-thumbnail');
                 $(img).attr("draggable", false);
-                addTitle(element, $element, $name)
-            }
-            else {
+                addTitle(element, $name);
+            } else {
                 common.displayThumbnail(href || data.roHref, data.channel, data.password, $element, function ($thumb) {
                     // Called only if the thumbnail exists
                     // Remove the .hide() added by displayThumnail() because it hides the icon in list mode too
@@ -2230,8 +2245,7 @@ define([
                     $thumb.addClass('cp-app-drive-element-grid cp-app-drive-element-thumbnail');
                     $thumb.attr("draggable", false);
                     thumbsUrls[element] = $thumb[0].src;
-                    addTitle(element, $element, $name)
-
+                    addTitle(element, $name);
                 });
             }
 
@@ -2247,15 +2261,6 @@ define([
             }).text(getDate(data.ctime));
             $element.append($type).append($adate).append($cdate);
         };
-
-        var addTitle = function (element, $element, $name) {
-            var icon = getFileIcon(element)
-
-            $(icon).addClass('cp-app-drive-element-icon')
-            $name.addClass('cp-app-drive-element-name-icon')
-            $name.prepend($(icon))
-
-        }
 
         var addFolderData = function (element, key, $span) {
             if (!element || !manager.isFolder(element)) { return; }
@@ -2319,13 +2324,6 @@ define([
                 $span.append($menu);
             }
         };
-
-        // This is duplicated in cryptpad-common, it should be unified
-        var getFileIcon = function (id) {
-            var data = manager.getFileData(id);
-            return UI.getFileIcon(data);
-        };
-        var getIcon = UI.getIcon;
 
         var createShareButton = function (id, $container) {
             var $shareBlock = $('<button>', {


### PR DESCRIPTION
Fixes #1351. The icons are only displayed for drive files in list mode, or, when in grid mode, as part of the file name, only when the item has a thumbnail.