### PR TITLE
Cannot change shared folder password to the same string twice in a row

### DIFF
--- a/www/common/inner/access.js
+++ b/www/common/inner/access.js
@@ -815,6 +815,7 @@ define([
     };
 
     var getAccessTab = function (Env, data, opts, _cb) {
+        var oldPass = data.password;
         var cb = Util.once(Util.mkAsync(_cb));
         var common = Env.common;
         opts = opts || {};
@@ -903,8 +904,7 @@ define([
                 var pLocked = false;
                 $(passwordOk).click(function () {
                     var newPass = $(newPassword).find('input').val();
-                    if (data.password === newPass ||
-                        (!data.password && !newPass)) {
+                    if (oldPass === newPass || !oldPass && !newPass) {
                         return void UI.alert(Messages.properties_passwordSame);
                     }
                     if (pLocked) { return; }
@@ -1003,6 +1003,8 @@ define([
                                         return sframeChan.query('Q_PASSWORD_CHECK', newPass, () => { common.gotoURL(_href);  });
                                     }
                                     common.gotoURL(_href);
+                                } else {
+                                    oldPass = newPass;
                                 }
                             });
                         });


### PR DESCRIPTION
Fixes #1365.