### PR TITLE
Fix richtext issues (#1336 + ~#1358 + #1226)

### DIFF
--- a/customize.dist/ckeditor-config.js
+++ b/customize.dist/ckeditor-config.js
@@ -13,7 +13,7 @@ CKEDITOR.editorConfig = function( config ) {
     config.removeButtons= 'Source,Maximize';
     // magicline plugin inserts html crap into the document which is not part of the
     // document itself and causes problems when it's sent across the wire and reflected back
-    config.removePlugins= 'resize,elementspath,contextmenu,liststyle,tabletools,tableselection';
+    config.removePlugins= 'resize,elementspath,liststyle';
     config.resize_enabled= false; //bottom-bar
     config.extraPlugins= 'autolink,colorbutton,colordialog,font,indentblock,justify,mediatag,print,blockbase64,mathjax,wordcount,comments';
     config.toolbarGroups= [

--- a/www/pad/inner.js
+++ b/www/pad/inner.js
@@ -420,7 +420,7 @@ define([
                         info.node.getAttribute('class').split(' ').indexOf('cke_image_resizer') !== -1)) {
                     return true;
                 }
-                // CkEditor temporary data (used when copy-paste large chunks for instance
+                // CkEditor temporary data (used when copy-paste large chunks for instance)
                 if (info.node && (info.node.tagName === 'SPAN' || info.node.tagName === 'DIV') && info.diff.name === 'data-cke-temp') {
                     return true;
                 }

--- a/www/pad/inner.js
+++ b/www/pad/inner.js
@@ -112,7 +112,7 @@ define([
     // * Remove the drag&drop and resizers from the hyperjson
     var isWidget = function(el) {
         return typeof(el.getAttribute) === "function" &&
-            (el.getAttribute('data-cke-hidden-sel') ||
+            (el.getAttribute('data-cke-hidden-sel') || el.getAttribute('data-cke-temp') ||
                 (el.getAttribute('class') &&
                     (/cke_widget_drag/.test(el.getAttribute('class')) ||
                         /cke_image_resizer/.test(el.getAttribute('class')))
@@ -418,6 +418,10 @@ define([
                     info.node.getAttribute('class') &&
                     (info.node.getAttribute('class').split(' ').indexOf('cke_widget_drag_handler') !== -1 ||
                         info.node.getAttribute('class').split(' ').indexOf('cke_image_resizer') !== -1)) {
+                    return true;
+                }
+                // CkEditor temporary data (used when copy-paste large chunks for instance
+                if (info.node && (info.node.tagName === 'SPAN' || info.node.tagName === 'DIV') && info.diff.name === 'data-cke-temp') {
                     return true;
                 }
 

--- a/www/pad/links.js
+++ b/www/pad/links.js
@@ -27,6 +27,7 @@ define([
                 try {
                     var foundAnchor = false;
                     $inner.find('.cke_anchor[data-cke-realelement]').each(function (j, el) {
+                        if (foundAnchor) { return; }
                         var i = editor.restoreRealElement($(el));
                         var node = i.$;
                         if (node.id === href.slice(1)) {
@@ -36,7 +37,7 @@ define([
                     });
                     if (!foundAnchor) {
                         var anchorsById = $inner.find('#' + href.slice(1));
-                        if (anchorsById.length != 0) { anchorsById[0].scrollIntoView(); }
+                        if (anchorsById.length) { anchorsById[0].scrollIntoView(); }
                     }
                 } catch (err) {}
                 return;

--- a/www/pad/links.js
+++ b/www/pad/links.js
@@ -25,13 +25,19 @@ define([
         var open = function () {
             if (href[0] === '#') {
                 try {
+                    var foundAnchor = false;
                     $inner.find('.cke_anchor[data-cke-realelement]').each(function (j, el) {
                         var i = editor.restoreRealElement($(el));
                         var node = i.$;
                         if (node.id === href.slice(1)) {
                             el.scrollIntoView();
+                            foundAnchor = true;
                         }
                     });
+                    if (!foundAnchor) {
+                        var anchorsById = $inner.find('#' + href.slice(1));
+                        if (anchorsById.length != 0) { anchorsById[0].scrollIntoView(); }
+                    }
                 } catch (err) {}
                 return;
             }


### PR DESCRIPTION
Hi,

Here are some fixes that:
* Restore contextual menu to be able to edit tables again (as mentionned in [this comment](https://github.com/cryptpad/cryptpad/issues/1358#issuecomment-1886761694)).
* Filter out some non-displayed content used by ckeditor on chrome for clipboard management that caused duplicated elements in table of contents (#1336).
* Anchors that are created by selecting a text before creating the anchor are now working within the Richtext app in CryptPad (#1226)