### PR TITLE
Fix ssoauth path regex

### DIFF
--- a/customize.dist/template.js
+++ b/customize.dist/template.js
@@ -69,7 +69,7 @@ $(function () {
                 require([ '/install/main.js' ], function () {});
             } else if (/^\/recovery\//.test(pathname)) {
                 require([ '/recovery/main.js' ], function () {});
-            } else if (/^\/ssoauth\//.test(pathname)) {
+            } else if (/^\/ssoauth/.test(pathname)) {
                 require([ '/ssoauth/main.js' ], function () {});
             } else if (/^\/login\//.test(pathname)) {
                 require([ '/login/main.js' ], function () {});


### PR DESCRIPTION
The ssoauth page is called without a trailing slash (presumably because of the GET-parameters). Therefore he regex for calling the main.js does not match and the rendered `/ssoauth` page is without function.

Fixes #1410