### PR TITLE
Fix Notifications replaying (#1399)

### DIFF
--- a/www/common/outer/mailbox.js
+++ b/www/common/outer/mailbox.js
@@ -480,20 +480,12 @@ proxy.mailboxes = {
                     }
                 }
                 var hash = _msg[4].slice(0,64);
-                Handlers.add(ctx, req.box, {
-                    hash,
-                    msg: message
-                }, function (dismissed, toDismiss, invalid) {
-                    // Show dismissed messages, hide invalid messages
-                    // Invalid: no content or impersonation attempt
-                    if (invalid) { return; }
-                    ctx.emit('HISTORY', {
-                        txid: txid,
-                        time: _msg[5],
-                        message: message,
-                        hash: hash
-                    }, [req.cId]);
-                });
+                ctx.emit('HISTORY', {
+                    txid: txid,
+                    time: _msg[5],
+                    message: message,
+                    hash: hash
+                }, [req.cId]);
             } else if (type === 'HISTORY_RANGE_END') {
                 ctx.emit('HISTORY', {
                     txid: txid,

--- a/www/common/outer/mailbox.js
+++ b/www/common/outer/mailbox.js
@@ -468,7 +468,7 @@ proxy.mailboxes = {
             if (type === 'HISTORY_RANGE') {
                 if (!Array.isArray(_msg)) { return; }
                 var message;
-                if (req.box.type === 'broadcast') {
+                if (req.box.type === 'broadcast') {
                     message = Util.tryParse(_msg[4]);
                 } else {
                     try {


### PR DESCRIPTION
This PR fixes the near-infinite creation of notifications on team acceptance as reported in #1399.

It disables re-executing notification handlers when replaying history.