### PR TITLE
fix image name in docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ version: '3.8'
 
 services:
   cryptpad:
-    image: "cryptpad/cryptpad:version-2024.3.0"
+    image: "cryptpad/cryptpad:version-2024.03.0"
     hostname: cryptpad
 
     environment:


### PR DESCRIPTION
As can be seen on <https://hub.docker.com/r/cryptpad/cryptpad/tags> the image tag has a leading `0` in the tag. Either that tag is wrong, or the docker compose file is wrong. Here is a PR to fix the docker compose file.