### PR TITLE
#1465: unsharp the corners when hovering the dismiss button on notification dropdown menu

### DIFF
--- a/customize.dist/src/less2/include/notifications.less
+++ b/customize.dist/src/less2/include/notifications.less
@@ -36,9 +36,6 @@
             }
             .cp-reminder, .cp-avatar {
                 cursor: pointer;
-                &:hover {
-                    background-color: @cp_dropdown-bg-hover;
-                }
             }
             .cp-avatar {
                 .avatar_main(30px);
@@ -61,9 +58,6 @@
                 }
                 &.cp-clickable {
                     cursor: pointer;
-                    &:hover {
-                        background-color: @cp_dropdown-bg-hover;
-                    }
                 }
             }
             .cp-notification-dismiss {
@@ -73,9 +67,6 @@
                 align-items: center;
                 justify-content: center;
                 cursor: pointer;
-                &:hover {
-                    background-color: @cp_dropdown-bg-hover;
-                }
             }
         }
     }


### PR DESCRIPTION
Hello,

This PR fixes #1465 by removing drawing over the background when mouse hover some elements in the notification dropdown. Especially the dismiss (❌) button that was visible as it is not rounded.
