### PR TITLE
Fix locked focus on text editors

### DIFF
--- a/customize.dist/src/less2/include/toolbar.less
+++ b/customize.dist/src/less2/include/toolbar.less
@@ -77,6 +77,12 @@
             &:hover {
                 background-color: contrast(@cp_toolbar-bg, darken(@cp_toolbar-bg, 5%), lighten(@cp_toolbar-bg, 5%));
             }
+            &:focus {
+                outline: @cryptpad_color_brand solid 2px;
+            }
+        }
+        button:nth-of-type(1){
+            margin-left: 0.3rem;
         }
     }
 

--- a/www/common/sframe-common-codemirror.js
+++ b/www/common/sframe-common-codemirror.js
@@ -177,9 +177,9 @@ define([
                     }
                 },
                 //remove focus from editor
-                "Shift-Enter": function () {
+                "Esc": function () {
                     document.activeElement.blur();
-                    document.querySelector('[tabindex="0"]').focus();
+                    document.querySelector('.cp-toolbar-link-logo').focus();
                 },
                 "Shift-Tab": function () {
                     editor.execCommand("indentLess");

--- a/www/common/sframe-common-codemirror.js
+++ b/www/common/sframe-common-codemirror.js
@@ -176,6 +176,11 @@ define([
                         else { editor.execCommand("insertTab"); }
                     }
                 },
+                //remove focus from editor
+                "Shift-Enter": function () {
+                    document.activeElement.blur();
+                    document.querySelector('[tabindex="0"]').focus();
+                },
                 "Shift-Tab": function () {
                     editor.execCommand("indentLess");
                 },


### PR DESCRIPTION
This PR aims to fix #1208, so that every user can navigate into and out of text editors using only the keyboard