### PR TITLE
Fix bash indentation and trailing whitespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This release introduces a new onboarding flow to guide administrators through th
 
 - Onboarding screens & app configuration [#1513](https://github.com/cryptpad/cryptpad/pull/1513)
 - Bahasa Indonesia is a new available language [fe78b6a](https://github.com/cryptpad/cryptpad/commit/fe78b6ab1dc76ce9eb8d5361c309db8e92117fa8)
-  - Thanks to our [Weblate](https://weblate.cryptpad.org) contributors who made that happen! 
+  - Thanks to our [Weblate](https://weblate.cryptpad.org) contributors who made that happen!
 
 ## Improvements
 
@@ -46,7 +46,7 @@ This release introduces a new onboarding flow to guide administrators through th
   - Switch to new `http2` Nginx option [#1516](https://github.com/cryptpad/cryptpad/pull/1516)
   - Server fixes and aggregated stats [#1509](https://github.com/cryptpad/cryptpad/pull/1509)
   - Create the block folder at boot [#911](https://github.com/cryptpad/cryptpad/pull/911)
-  - Remove obsolete `version` from `docker-compose.yml` [2e716eb](https://github.com/cryptpad/cryptpad/commit/2e716eb4e39fb835f95a1fa1a340e01142d11b1c) 
+  - Remove obsolete `version` from `docker-compose.yml` [2e716eb](https://github.com/cryptpad/cryptpad/commit/2e716eb4e39fb835f95a1fa1a340e01142d11b1c)
 - Other
   - Unsharp the corners when hovering the dismiss button on notification drop-down menu [#1466](https://github.com/cryptpad/cryptpad/pull/1466)
   - Fix contextual menu `Open` on anonymous drive [#1464](https://github.com/cryptpad/cryptpad/pull/1464)

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY . /cryptpad
 
 RUN sed -i "s@//httpAddress: 'localhost'@httpAddress: '0.0.0.0'@" /cryptpad/config/config.example.js
 RUN sed -i "s@installMethod: 'unspecified'@installMethod: 'docker'@" /cryptpad/config/config.example.js
-  
+
 # Install dependencies
 RUN npm install --production \
     && npm run install:components

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) <year> <owner>. 
+Copyright (c) <year> <owner>.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSES/MPL-2.0.txt
+++ b/LICENSES/MPL-2.0.txt
@@ -35,7 +35,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,16 +22,16 @@ if [ ! -f "$CPAD_CONF" ]; then
          eg: docker run -v /path/to/config.js:/cryptpad/config/config.js \n\
          #################################################################### \n"
 
-	cp "$CPAD_HOME"/config/config.example.js "$CPAD_CONF"
+    cp "$CPAD_HOME"/config/config.example.js "$CPAD_CONF"
 
-	sed -i  -e "s@\(httpUnsafeOrigin:\).*[^,]@\1 '$CPAD_MAIN_DOMAIN'@" \
+    sed -i  -e "s@\(httpUnsafeOrigin:\).*[^,]@\1 '$CPAD_MAIN_DOMAIN'@" \
         -e "s@\(^ *\).*\(httpSafeOrigin:\).*[^,]@\1\2 '$CPAD_SANDBOX_DOMAIN'@" "$CPAD_CONF"
 fi
 
 cd $CPAD_HOME
 
 if [ "$CPAD_INSTALL_ONLYOFFICE" == "yes" ]; then
-	./install-onlyoffice.sh --accept-license
+    ./install-onlyoffice.sh --accept-license
 fi
 
 npm run build

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ The most recent version and all past release notes can be found on the [releases
 
 ## Setup using Docker
 
-You can find `Dockerfile`, `docker-compose.yml` and `docker-entrypoint.sh` files at the root of this repository. We also publish every release on [Docker Hub](https://hub.docker.com/r/cryptpad/cryptpad) as AMD64 & ARM64 official images. 
+You can find `Dockerfile`, `docker-compose.yml` and `docker-entrypoint.sh` files at the root of this repository. We also publish every release on [Docker Hub](https://hub.docker.com/r/cryptpad/cryptpad) as AMD64 & ARM64 official images.
 
 Previously, Docker images were community maintained, had their own repository and weren't official supported. We changed that with v5.4.0 during July 2023. Thanks to @promasu for all the work on the community images.
 

--- a/scripts/convert-favicons-to-ico.sh
+++ b/scripts/convert-favicons-to-ico.sh
@@ -5,6 +5,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 for f in ../customize.dist/favicon/*.png; do
-	base="$(basename $f ".png")"
-	magick convert $f -define icon:auto-resize=16,24,32,48,64,72,96,128,256 "$base.ico"
+    base="$(basename $f ".png")"
+    magick convert $f -define icon:auto-resize=16,24,32,48,64,72,96,128,256 "$base.ico"
 done


### PR DESCRIPTION
Some shell scripts had tabs indentation. Made it all four spaces. Hope it's ok with spaces.

Some files had a trailing space in it. It was not useful and takes few bytes for nothing.

I didn't delete everything, but I can make a new PR if needed.

You can find all tab indented lines with:

grep -rP '^\t' 2>/dev/null

And more trailing space with:
grep -rP ' $' 2>/dev/null