### PR TITLE
Allow docker containers to download plugins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - CPAD_MAIN_DOMAIN=https://your-main-domain.com
       - CPAD_SANDBOX_DOMAIN=https://your-sandbox-domain.com
       - CPAD_CONF=/cryptpad/config/config.js
+      # Add SSO plugin from git's "main" branch, but can be a commit hash or a tag
+      #- CPAD_PLUGIN_SSO=https://github.com/cryptpad/sso.git|main
 
       # Read and accept the license before uncommenting the following line:
       # https://github.com/ONLYOFFICE/web-apps/blob/master/LICENSE.txt
@@ -23,6 +25,8 @@ services:
       - ./customize:/cryptpad/customize
       - ./data/data:/cryptpad/data
       - ./data/files:/cryptpad/datastore
+      # Useful if you want to store plugins and avoid downloading them all the time
+      #- ./data/plugins:/cryptpad/lib/plugins
       - ./onlyoffice-dist:/cryptpad/www/common/onlyoffice/dist
       - ./onlyoffice-conf:/cryptpad/onlyoffice-conf
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,6 +12,7 @@
 set -e
 
 CPAD_HOME="/cryptpad"
+PLUGIN_COMMIT_SEPARATOR='|'
 
 if [ ! -f "$CPAD_CONF" ]; then
     echo -e "\n\
@@ -27,6 +28,55 @@ if [ ! -f "$CPAD_CONF" ]; then
 	sed -i  -e "s@\(httpUnsafeOrigin:\).*[^,]@\1 '$CPAD_MAIN_DOMAIN'@" \
         -e "s@\(^ *\).*\(httpSafeOrigin:\).*[^,]@\1\2 '$CPAD_SANDBOX_DOMAIN'@" "$CPAD_CONF"
 fi
+
+# Find all environment variable names starting with "CPAD_PLUGIN_"
+PLUGIN_LIST=$(env | sed -n '/^CPAD_PLUGIN_/{s@=.*$@@g;p}')
+
+for PLUGIN in $PLUGIN_LIST; do
+    # Retrieve the plugin name from the end of the environment variable name
+    PLUGIN_NAME=$(echo "$PLUGIN" | sed 's@^CPAD_PLUGIN_@@' | \
+        tr '[:upper:]' '[:lower:]')
+
+    # Plugins are stored in the lowercase suffix of their variable name.
+    # Example: "CPAD_PLUGIN_SSO" will create the directory "sso"
+    PLUGIN_PATH="$CPAD_HOME/lib/plugins/$PLUGIN_NAME"
+
+    # Read the variable's value and split the git URL and the branch/tag
+    IFS="$PLUGIN_COMMIT_SEPARATOR" read -ra PLUGIN_VALUES <<<"${!PLUGIN}"
+    PLUGIN_URL="${PLUGIN_VALUES[0]}"
+    PLUGIN_BRANCH_OR_TAG="${PLUGIN_VALUES[1]}"
+
+    if [ ! -d "$PLUGIN_PATH" ]; then
+        # The directory does not exist and need to be cloned
+        git clone "$PLUGIN_URL" "$PLUGIN_PATH"
+    else
+        echo "Plugin $PLUGIN_NAME already present, not cloning it."
+    fi
+
+    # Change the working directory to the git path
+    pushd "$PLUGIN_PATH"
+
+    if [ -z "$PLUGIN_BRANCH_OR_TAG" ]; then
+        # No branch was specified, using the default git branch
+        DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s@.*: @@p')
+        PLUGIN_BRANCH_OR_TAG="$DEFAULT_BRANCH"
+    fi
+
+    # Retrieve the content and go to the commit/branch
+    git fetch
+    git checkout "$PLUGIN_BRANCH_OR_TAG"
+
+    # Returns the number of branches matching the branch/commit/tags value
+    # Should be 1 if a remote branch matches with the value
+    IS_BRANCH=$(git branch -r | grep "origin/$PLUGIN_BRANCH_OR_TAG$" | wc -l)
+    if [ "$IS_BRANCH" -gt 0 ]; then
+        # Merge local branch with remote branch
+        git merge
+    fi
+
+    # Rollback the working directory to the old path
+    popd
+done
 
 cd $CPAD_HOME
 


### PR DESCRIPTION
It allows automatic installation of plugins for docker.

There can be multiple plugins, with one variable each. As long as the environment variable starts with "CPAD_PLUGIN_", the suffix will then be used to define the plugin git directory in lib/plugins/.

It also allows to pick which commit, tag or branch we want to use, by appending it to the git URL, separated by a '|' for now.

If the commit/tag/branch part is ommited, the default is to use the git's default branch. The repository is synced at every restart, so it's probably better to specify which tag or commit hash we want, if this is a plugin with a lot of activity.

The end result is commented in the docker-compose.yml to avoid confusing people who use docker and don't need plugins.