### PR TITLE
`Ctrl+E` modal fixes

### DIFF
--- a/customize.dist/src/less2/include/drive.less
+++ b/customize.dist/src/less2/include/drive.less
@@ -953,6 +953,9 @@
             li, li .fa, li .cptools {
                 cursor: pointer;
                 border-radius: @variables_radius;
+                &:focus {
+                    outline: @cryptpad_color_brand solid 2px;
+                }
             }
             &> p {
                 display: flex;

--- a/customize.dist/src/less2/include/icons.less
+++ b/customize.dist/src/less2/include/icons.less
@@ -33,8 +33,8 @@
             color: @cp_drive-fg;
         }
         &.cp-icons-element-selected {
-            background: @cp_drive-icon-hover;
             color: @cp_drive-fg;
+            outline: @cryptpad_color_brand solid 2px;
         }
         .fa, .cptools {
             display: block;

--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -670,6 +670,7 @@ define([
             $modal: $blockContainer,
             show: function () {
                 $blockContainer.css('display', 'flex');
+                addTabListener($blockContainer);
             },
             hide: hide
         };


### PR DESCRIPTION
This PR aims to fix accessibility issues for the `Ctrl+E` modal:
- #1558
- #1506  (updated the styling for this modal)