### PR TITLE
env.js: fix httpSafePort handling

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -104,7 +104,7 @@ module.exports = {
  *
  *  In production environments, your reverse proxy (usually NGINX)
  *  will need to forward websocket traffic (/cryptpad_websocket)
- *  to this port.
+ *  to this port - it cannot be disabled.
  *
  */
     // websocketPort: 3003,

--- a/config/config.example.js
+++ b/config/config.example.js
@@ -89,8 +89,9 @@ module.exports = {
 
 /*  httpSafePort purpose is to emulate another origin for the sandbox when
  *  you don't have two domains at hand (i.e. when httpSafeOrigin not defined).
- *  It is meant to be used only in case where you are working on a local 
+ *  It is meant to be used only in case where you are working on a local
  *  development instance. The default value is your httpPort + 1.
+ *  Setting this to 0 or setting httpSafeOrigin disables this listener.
  *
  */
     //httpSafePort: 3001,

--- a/lib/env.js
+++ b/lib/env.js
@@ -74,8 +74,9 @@ module.exports.create = function (config) {
 
     if (typeof(config.httpSafeOrigin) !== 'string') {
         NO_SANDBOX = true;
-        if (typeof(config.httpSafePort) !== 'number') { httpSafePort = httpPort + 1; }
         httpSafeOrigin = deriveSandboxOrigin(httpUnsafeOrigin, httpSafePort);
+        // only set if httpSafeOrigin isn't set.
+        httpSafePort = isValidPort(config.httpSafePort) ? config.httpSafePort : (httpPort + 1);
     } else {
         httpSafeOrigin = canonicalizeOrigin(config.httpSafeOrigin);
     }
@@ -115,7 +116,7 @@ module.exports.create = function (config) {
         permittedEmbedders: typeof(permittedEmbedders) === 'string' && permittedEmbedders? permittedEmbedders: httpSafeOrigin,
 
         removeDonateButton: config.removeDonateButton,
-        httpPort: isValidPort(config.httpPort)? config.httpPort: 3000,
+        httpPort: httpPort,
         httpAddress: typeof(config.httpAddress) === 'string'? config.httpAddress: 'localhost',
         websocketPath: config.externalWebsocketURL,
         logIP: config.logIP,

--- a/lib/env.js
+++ b/lib/env.js
@@ -68,12 +68,10 @@ module.exports.create = function (config) {
     var httpUnsafeOrigin = canonicalizeOrigin(config.httpUnsafeOrigin);
 
     var httpSafeOrigin;
-    var NO_SANDBOX = false;
     var httpSafePort;
     var httpPort = isValidPort(config.httpPort)? config.httpPort: 3000;
 
     if (typeof(config.httpSafeOrigin) !== 'string') {
-        NO_SANDBOX = true;
         httpSafeOrigin = deriveSandboxOrigin(httpUnsafeOrigin, httpSafePort);
         // only set if httpSafeOrigin isn't set.
         httpSafePort = isValidPort(config.httpSafePort) ? config.httpSafePort : (httpPort + 1);
@@ -100,7 +98,6 @@ module.exports.create = function (config) {
         protocol: new URL(httpUnsafeOrigin).protocol,
 
         fileHost: config.fileHost || undefined,
-        NO_SANDBOX: NO_SANDBOX,
         httpSafePort: httpSafePort,
         websocketPort: config.websocketPort,
 


### PR DESCRIPTION
This is a follow-up of #1212 I had opened last year:

- The httpSafePort config item didn't work at all even if httpSafeOrigin wasn't set, so make it work.
- Since then the comment in the config has been clarified in #1518, but it still isn't clear enough as seen in #1514 -- improve the comment a bit.
- While here also make it clear that the websocket port is not optional
- ... and remove unused NO_SANDBOX variable in env.js that was adjacent to the httpSafePort setting; this probably doesn't really belong here but cannot hurt.

all in all there is nothing impacting any production setup, but might as well finish this so I can get it off my todo. Thanks!