### PR TITLE
Apply default padding to Rich-Text buttons

### DIFF
--- a/www/pad/app-pad.less
+++ b/www/pad/app-pad.less
@@ -60,6 +60,7 @@ body.cp-app-pad {
             cursor: pointer;
             height: 28px;
             line-height: 28px;
+            padding: 0px 6px;
             .fa { margin: 0 !important; }
         }
         &.hidden {


### PR DESCRIPTION
Fix an issue where the button icons were pushed down beyond the outline