### PR TITLE
Disable arrow key navigation in the drive while modal is active

### DIFF
--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2514,6 +2514,7 @@ define([
             else if (e.which === 13) {
                 if ($container.find('.cp-icons-element-selected').length === 1) {
                     $container.find('.cp-icons-element-selected').click();
+                    return;
                 }
             }
         });

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2511,13 +2511,13 @@ define([
                     next();
                 }
                 return;
-              }
+            }
             if (e.which === 13) {
                 if ($container.find('.cp-icons-element-selected').length === 1) {
                     $container.find('.cp-icons-element-selected').click();
                 }
+                return;
             }
-            return;
         });
 
 

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2510,13 +2510,14 @@ define([
                 } else {
                     next();
                 }
+                return;
               }
-            else if (e.which === 13) {
+            if (e.which === 13) {
                 if ($container.find('.cp-icons-element-selected').length === 1) {
                     $container.find('.cp-icons-element-selected').click();
-                    return;
                 }
             }
+            return;
         });
 
 

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2510,13 +2510,11 @@ define([
                 } else {
                     next();
                 }
-                return;
-            }
-            if (e.which === 13) {
+              }
+            else if (e.which === 13) {
                 if ($container.find('.cp-icons-element-selected').length === 1) {
                     $container.find('.cp-icons-element-selected').click();
                 }
-                return;
             }
         });
 
@@ -2525,6 +2523,7 @@ define([
         window.setTimeout(function () {
             modal.show();
             $modal.focus();
+            next();
         });
     };
 

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -1045,9 +1045,7 @@ define([
             // If the arrow keys aren't caught by another listener before, it means we can
             // use them to select content in the drive. If that's the case, we'll also
             // focus the drive container to avoid conflicts with other focused elements
-            if (!$('.cp-modal').is(':visible')) {
-                $content.focus();
-            }
+            $content.focus();
 
             var click = function (el) {
                 if (!el) { return; }
@@ -1062,6 +1060,11 @@ define([
                             $elements.index($selection.last()[0]);
             var length = $elements.length;
             if (length === 0) { return; }
+
+            if ($('.cp-modal').is(':visible')) {
+                return;
+            }
+
             // List mode
             if (getViewMode() === "list") {
                 if (e.which === 40) { click($elements.get(Math.min(lastIndex+1, length -1))); }

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -1045,7 +1045,9 @@ define([
             // If the arrow keys aren't caught by another listener before, it means we can
             // use them to select content in the drive. If that's the case, we'll also
             // focus the drive container to avoid conflicts with other focused elements
-            $content.focus();
+            if (!$('.cp-modal').is(':visible')) {
+                $content.focus();
+            }
 
             var click = function (el) {
                 if (!el) { return; }

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -990,6 +990,9 @@ define([
         // Arrow keys to modify the selection
         var onWindowKeydown = function (e) {
             if (!$content.is(':visible')) { return; }
+            if ($('.cp-modal').is(':visible')) {
+                return;
+            }
             var $searchBar = $tree.find('#cp-app-drive-tree-search-input');
             if (document.activeElement && document.activeElement.nodeName === 'INPUT') { return; }
             if ($searchBar.is(':focus') && $searchBar.val()) { return; }
@@ -1060,10 +1063,6 @@ define([
                             $elements.index($selection.last()[0]);
             var length = $elements.length;
             if (length === 0) { return; }
-
-            if ($('.cp-modal').is(':visible')) {
-                return;
-            }
 
             // List mode
             if (getViewMode() === "list") {

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -1063,7 +1063,6 @@ define([
                             $elements.index($selection.last()[0]);
             var length = $elements.length;
             if (length === 0) { return; }
-
             // List mode
             if (getViewMode() === "list") {
                 if (e.which === 40) { click($elements.get(Math.min(lastIndex+1, length -1))); }


### PR DESCRIPTION
This PR disables the use of arrow keys inside the drive while a modal is open, fixing #1660.
Previously, arrow keys could still be used to navigate files in the background, which could lead to unintended behavior or conflicts when interacting with the modal. Now, the arrow keys are disabled inside the drive while a modal is opened.