### PR TITLE
Fix keyboard trap inside Form description

### DIFF
--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -1097,6 +1097,11 @@ define([
                             block = h('div.cp-form-edit-options-block', [t]);
                             cm = SFCodeMirror.create("gfm", CMeditor, t);
                             editor = cm.editor;
+                            editor.setOption("extraKeys", {
+                                "Esc": function () {
+                                    editor.display.input.blur();
+                                },
+                            });
                             editor.setOption('lineNumbers', true);
                             editor.setOption('lineWrapping', true);
                             editor.setOption('styleActiveLine', true);


### PR DESCRIPTION
This PR fixes a keyboard trap found inside the Form description. I've added the `Esc` option in order to remove the focus from the text field (this option is also used for other CodeMirror usages), fixing #1638.