### PR TITLE
Server worker issues

### DIFF
--- a/lib/workers/index.js
+++ b/lib/workers/index.js
@@ -152,7 +152,18 @@ Workers.initialize = function (Env, config, _cb) {
         // default to timing out affter 180s if no explicit timeout is passed
         var timeout = typeof(opt.timeout) !== 'undefined'? opt.timeout: DEFAULT_QUERY_TIMEOUT;
         response.expect(txid, cb, timeout);
+
+        delete msg._cb;
+        delete msg._opt;
         state.worker.send(msg);
+
+        // Add original callback to message data in case we need
+        // to resend the command. setTimeout to avoid interfering
+        // with worker.send
+        setTimeout(function () {
+            msg._cb = _cb;
+            msg._opt = opt;
+        });
     };
 
     var handleResponse = function (state, res) {
@@ -237,26 +248,36 @@ Workers.initialize = function (Env, config, _cb) {
                 const cb = response.expectation(txid);
                 if (typeof(cb) !== 'function') { return; }
                 const task = state.tasks[txid];
-                if (!(task && task.msg)) { return; }
+                if (!task) { return; }
                 response.clear(txid);
-                Log.info('DB_WORKER_RESEND', task.msg);
-                sendCommand(task.msg, cb);
+                Log.info('DB_WORKER_RESEND', task);
+                sendCommand(task, task._cb || cb, task._opt);
             });
 
             var w = fork(DB_PATH);
-            initWorker(w, function (err, state) {
+            initWorker(w, function (err) {
                 if (err) {
                     throw new Error(err);
                 }
-                workers.push(state);
             });
         });
 
-        worker.on('exit', substituteWorker);
-        worker.on('close', substituteWorker);
+        worker.on('exit', function () {
+            substituteWorker();
+            Env.Log.error("DB_WORKER_EXIT", {
+                pid: state.pid,
+            });
+        });
+        worker.on('close', function () {
+            substituteWorker();
+            Env.Log.error("DB_WORKER_CLOSE", {
+                pid: state.pid,
+            });
+        });
         worker.on('error', function (err) {
             substituteWorker();
             Env.Log.error("DB_WORKER_ERROR", {
+                pid: state.pid,
                 error: err,
             });
         });


### PR DESCRIPTION
* Fix issue with newly spawned workers added twice to the list after a crash
  * This meant the new worker had twice as much tasks as the others
* Fix issue when dispatching tasks of a crashed worker to the other ones
  * The wrong data was sent to the other workers so these tasks couldn't be executed