### PR TITLE
Fix spacing issues in Forms 

### DIFF
--- a/customize.dist/src/less2/include/checkmark.less
+++ b/customize.dist/src/less2/include/checkmark.less
@@ -137,7 +137,7 @@
     }
 
     .cp-radio {
-        margin: 0.2rem 0 0.2rem 0;
+        margin: 0;
         display: flex;
         align-items: center;
         position: relative;

--- a/www/form/app-form.less
+++ b/www/form/app-form.less
@@ -1319,6 +1319,9 @@
                     }
                 }
             }
+            .cp-radio {
+                margin: 0.2rem 0;
+            }
             .cp-form-status {
                 margin-bottom: 0.2rem;
             }


### PR DESCRIPTION
Hello,

This PR addresses multiple spacing and padding issues in the Forms app:
- Fixes insufficient spacing between elements in the form settings modal ([#1644](https://github.com/cryptpad/cryptpad/issues/1644)).
- Fixes missing padding for radio and checkbox buttons inside form questions ([#1642](https://github.com/cryptpad/cryptpad/issues/1642)), which also resolves issue [#1507](https://github.com/cryptpad/cryptpad/issues/1507). This ensures better distinction between options.