### PR TITLE
Prevent links in trash from disappearing after drive reload

### DIFF
--- a/www/common/outer/userObject.js
+++ b/www/common/outer/userObject.js
@@ -698,7 +698,7 @@ define([
                     }
                     if (exp.isFolder(obj.element)) { fixRoot(obj.element); }
                     if (typeof obj.element === "number") {
-                        var data = files[FILES_DATA][obj.element];
+                        var data = files[FILES_DATA][obj.element] || files[STATIC_DATA][obj.element];
                         if (!data) {
                             debug("An element in TRASH doesn't have associated data", obj.element, el);
                             toClean.push(idx);


### PR DESCRIPTION
* When a link is moved to the trash, and the browser page refreshed, it now stays in the trash until it is removed / destroyed instead of disappearing (fixes #1696)