### PR TITLE
Fix some form storage-related bugs

### DIFF
--- a/www/common/cryptpad-common.js
+++ b/www/common/cryptpad-common.js
@@ -928,13 +928,15 @@ define([
             delete meta.cursor;
 
             if (meta.type === "form") {
-                // Keep anonymous and makeAnonymous values from templates
+                // Keep anonymous, makeAnonymous and submit message values from templates
                 var anonymous = parsed.answers.anonymous || false;
                 var makeAnonymous = parsed.answers.makeAnonymous || false;
+                var msg = parsed.answers.msg || undefined;
                 delete parsed.answers;
                 parsed.answers = {
                     anonymous: anonymous,
-                    makeAnonymous: makeAnonymous
+                    makeAnonymous: makeAnonymous,
+                    msg: msg
                 };
             }
         }

--- a/www/form/templates.js
+++ b/www/form/templates.js
@@ -44,7 +44,10 @@ define([
                     }
                 }
             },
-            order: ["1", "2"]
+            order: ["1", "2"],
+            metadata: {
+                title: Messages.form_template_poll
+            }
         }
     }];
 });


### PR DESCRIPTION
This PR proposes a solution for:
- [x] the “quick scheduling poll” not storing properly as notified by #1718.
- [x] missing “submit message” when making a copy of a form #1716 

The solution for #1718 changes the behaviour of CryptPad as it creates a “quick schedule poll”-named file instead of the default generated filename. However it coincides better with real templates. When creating a file, it inherits the template name.