### PR TITLE
Add option to disable anonymous pad creation on the server side

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -174,6 +174,17 @@ module.exports = {
     ],
 
     /* =====================
+     *      PERMISSIONS
+     * ===================== */
+
+    /*  Prevent anonymous users from creating new pads (including user objects,
+     *  and other internal pads).
+     *  This setting works on the server side, so it should in theory
+     *  work against malicious clients.
+     */
+    // disableAnonymousPadCreationServerside: false,
+
+    /* =====================
      *        STORAGE
      * ===================== */
 

--- a/lib/env.js
+++ b/lib/env.js
@@ -119,6 +119,7 @@ module.exports.create = function (config) {
         httpAddress: typeof(config.httpAddress) === 'string'? config.httpAddress: 'localhost',
         websocketPath: config.externalWebsocketURL,
         logIP: config.logIP,
+        disableAnonymousPadCreationServerside: config.disableAnonymousPadCreationServerside,
 
         OFFLINE_MODE: false,
         FRESH_KEY: '',

--- a/lib/hk-util.js
+++ b/lib/hk-util.js
@@ -7,6 +7,7 @@ var HK = module.exports;
 const nThen = require('nthen');
 const Util = require("./common-util");
 const MetaRPC = require("./commands/metadata");
+const Users = require("./commands/users");
 const Nacl = require('tweetnacl/nacl-fast');
 const now = function () { return (new Date()).getTime(); };
 const ONE_DAY = 1000 * 60 * 60 * 24; // one day in milliseconds
@@ -737,16 +738,54 @@ const handleGetHistory = function (Env, Server, seq, userId, parsed) {
                 return;
             }
 
+            var sendEnd = function() {
+                // End of history message:
+                let parsedMsg = {state: 1, channel: channelName, txid: txid};
+
+                Server.send(userId, [0, HISTORY_KEEPER_ID, 'MSG', userId, JSON.stringify(parsedMsg)]);
+            };
+
             if (msgCount === 0 && !metadata_cache[channelName] && Server.channelContainsUser(channelName, userId)) {
-                // TODO this might be a good place to reject channel creation by anonymous users
-                handleFirstMessage(Env, channelName, metadata);
-                Server.send(userId, [0, HISTORY_KEEPER_ID, 'MSG', userId, JSON.stringify(metadata)]);
+                var session = HK.getNetfluxSession(Env, userId);
+
+                var createPad = function() {
+                    handleFirstMessage(Env, channelName, metadata);
+                    Server.send(userId, [0, HISTORY_KEEPER_ID, 'MSG', userId, JSON.stringify(metadata)]);
+                    sendEnd();
+                };
+
+                if (!Env.disableAnonymousPadCreationServerside) {
+                    createPad();
+                    return;
+                }
+
+                // check if this is a registered user
+                Users.getAll(Env, function(err, data) {
+                    if (err) {
+                        Log.error("HK_GET_ALL_USERS", {
+                            err: err && err.message || err,
+                        });
+
+                        const parsedMsg = {error: 'Internal error', channel: channelName, txid: txid};
+                        Server.send(userId, [0, HISTORY_KEEPER_ID, 'MSG', userId, JSON.stringify(parsedMsg)]);
+                        return;
+                    }
+
+                    var registeredUsers = Object.keys(data);
+
+                    var ok = HK.isUserSessionAllowed(registeredUsers, session);
+
+                    if (!ok) {
+                        const parsedMsg = {error: 'ERESTRICTED', channel: channelName, txid: txid};
+                        Server.send(userId, [0, HISTORY_KEEPER_ID, 'MSG', userId, JSON.stringify(parsedMsg)]);
+                        return;
+                    }
+
+                    createPad();
+                });
+            } else {
+                sendEnd();
             }
-
-            // End of history message:
-            let parsedMsg = {state: 1, channel: channelName, txid: txid};
-
-            Server.send(userId, [0, HISTORY_KEEPER_ID, 'MSG', userId, JSON.stringify(parsedMsg)]);
         });
     });
 };

--- a/lib/http-worker.js
+++ b/lib/http-worker.js
@@ -612,6 +612,7 @@ var serveConfig = makeRouteCache(function () {
             defaultStorageLimit: Env.defaultStorageLimit,
             maxUploadSize: Env.maxUploadSize,
             premiumUploadSize: Env.premiumUploadSize,
+            disableAnonymousPadCreationServerside: Env.disableAnonymousPadCreationServerside,
             restrictRegistration: Env.restrictRegistration,
             appsToDisable: Env.appsToDisable,
             restrictSsoRegistration: Env.restrictSsoRegistration,

--- a/www/common/sframe-common.js
+++ b/www/common/sframe-common.js
@@ -498,7 +498,7 @@ define([
     };
     funcs.createPad = function (cfg, cb) {
         //var priv = ctx.metadataMgr.getPrivateData();
-        if (AppConfig.disableAnonymousPadCreation && !funcs.isLoggedIn()) {
+        if ((AppConfig.disableAnonymousPadCreation || ApiConfig.disableAnonymousPadCreationServerside) && !funcs.isLoggedIn()) {
             return void UI.errorLoadingScreen(Messages.mustLogin);
         }
         ctx.sframeChan.query("Q_CREATE_PAD", {


### PR DESCRIPTION
This is my first attempt at fixing #625 

Looks like concept of "user" is very ambiguous in cryptpad, so I assumed `Users.getAll` are the registered users.
As far as I understand, in registration-disabled mode, these include all users created by accepting an invitation.
The admin can also add users manually to that list, which sounds useful.
Not sure how this handles SSO though.
Also, should I allow admins to create pads, even if they're not in Users?

I'd appreciate suggestions about better ways of obtaining something akin to a list of registered users.

Also, AFAIU this only prevents creation of channels (which seems to include userobjects, drive, etc) but not pins, blocks, and possibly other kinds of things that could be abused by an attacker to store arbitrary data.
I don't have a good grasp of those, or a good way to test for that (looks like the official client won't try to do these things when not logged in) so I'd also appreciate any pointers on how to handle those things.

Also, I don't have much experience with JS, so my code probably looks very awkward and unidiomatic - sorry about that.