### PR TITLE
Add `--check`, `--rdfind`, `--no-rdfind` options to `install-onlyoffice.sh`

### DIFF
--- a/install-onlyoffice.sh
+++ b/install-onlyoffice.sh
@@ -37,7 +37,17 @@ main() {
     install_x2t v7.3+1 ab0c05b0e4c81071acea83f0c6a8e75f5870c360ec4abc4af09105dd9b52264af9711ec0b7020e87095193ac9b6e20305e446f2321a541f743626a598e5318c1
 
     rm -rf "$BUILDS_DIR"
-    if command -v rdfind &>/dev/null; then
+
+    if [ "${RDFIND+x}" != "x" ]; then
+        if command -v rdfind &>/dev/null; then
+            RDFIND="1"
+        else
+            RDFIND="0"
+        fi
+    fi
+
+    if [ "$RDFIND" = "1" ]; then
+        ensure_command_available rdfind
         rdfind -makehardlinks true -makeresultsfile false $OO_DIR/v*
     fi
 }
@@ -73,6 +83,18 @@ parse_arguments() {
             TRUST_REPOSITORY="1"
             shift
             ;;
+        --check)
+            CHECK="1"
+            shift
+            ;;
+        --rdfind)
+            RDFIND="1"
+            shift
+            ;;
+        --no-rdfind)
+            RDFIND="0"
+            shift
+            ;;
         *)
             show_help
             shift
@@ -103,9 +125,6 @@ show_help() {
     cat <<EOF
 install-onlyoffice installs or upgrades OnlyOffice.
 
-NOTE: When you have rdfind installed, it will be used to save ~650MB of disk
-space.
-
 OPTIONS:
     -h, --help
             Show this help.
@@ -119,6 +138,18 @@ OPTIONS:
             Automatically configure the cloned onlyoffice-builds repository
             as a safe.directory.
             https://git-scm.com/docs/git-config/#Documentation/git-config.txt-safedirectory
+
+    --check
+            Do not install OnlyOffice, only check if the existing installation
+            is up to date. Exits 0 if it is up to date, nonzero otherwise.
+
+    --rdfind
+            Run rdfind to save ~650MB of disk space.
+            If neither '--rdfind' nor '--no-rdfind' is specified, then rdfind
+            will only run if rdfind is installed.
+
+    --no-rdfind
+            Do not run rdfind, even if it is installed.
 
 EOF
     exit 1
@@ -143,7 +174,17 @@ install_version() {
     local LAST_DIR
     LAST_DIR=$(pwd)
 
-    if [ ! -e "$FULL_DIR"/.commit ] || [ "$(cat "$FULL_DIR"/.commit)" != "$COMMIT" ]; then
+    local ACTUAL_COMMIT="not installed"
+    if [ -e "$FULL_DIR"/.commit ]; then
+        ACTUAL_COMMIT="$(cat "$FULL_DIR"/.commit)"
+    fi
+
+    if [ "$ACTUAL_COMMIT" != "$COMMIT" ]; then
+        if [ ${CHECK+x} ]; then
+            echo "Wrong commit of $FULL_DIR found. Expected: $COMMIT. Actual: $ACTUAL_COMMIT"
+            exit 1
+        fi
+
         ensure_oo_is_downloaded
 
         rm -rf "$FULL_DIR"
@@ -166,22 +207,31 @@ install_version() {
 }
 
 install_x2t() {
-    ensure_command_available curl
-    ensure_command_available sha512sum
-    ensure_command_available unzip
-
     local VERSION=$1
     local HASH=$2
     local LAST_DIR
     LAST_DIR=$(pwd)
     local X2T_DIR=$OO_DIR/x2t
 
+    local ACTUAL_VERSION="not installed"
+    if [ -e "$X2T_DIR"/.version ]; then
+        ACTUAL_VERSION="$(cat "$X2T_DIR"/.version)"
+    fi
+
     if [ ! -e "$X2T_DIR"/.version ] || [ "$(cat "$X2T_DIR"/.version)" != "$VERSION" ]; then
+        if [ ${CHECK+x} ]; then
+            echo "Wrong version of x2t found. Expected: $VERSION. Actual: $ACTUAL_VERSION"
+            exit 1
+        fi
+
         rm -rf "$X2T_DIR"
         mkdir -p "$X2T_DIR"
 
         cd "$X2T_DIR"
 
+        ensure_command_available curl
+        ensure_command_available sha512sum
+        ensure_command_available unzip
         curl "https://github.com/cryptpad/onlyoffice-x2t-wasm/releases/download/$VERSION/x2t.zip" --location --output x2t.zip
         # curl "https://github.com/cryptpad/onlyoffice-x2t-wasm/releases/download/v7.3%2B1/x2t.zip" --location --output x2t.zip
         echo "$HASH x2t.zip" >x2t.zip.sha512


### PR DESCRIPTION
`--check` is useful for anyone who wants to check if their OnlyOffice
installation is up to date without actually installing it.

The `--rdfind/--no-rdfind` commands serve a few purposes:

1. It makes it clear that `rdfind` can still run even if you specify `--check`.
2. People can ensure that `rdfind` runs by specifying `--rdfind`, which
   helps if they accidentally uninstall `rdfind`.
3. People can now skip running `rdfind` even if they have `rdfind`
   installed.