### PR TITLE
Treat relative URLs in the sandbox as relative to the outer domain

### DIFF
--- a/www/common/sframe-common.js
+++ b/www/common/sframe-common.js
@@ -1057,6 +1057,11 @@ define([
 
             Mailbox.create(funcs);
 
+            // automatically configure all relative links in the inner iframe
+            // to point to the outer domain by adding a 'base' element to iframe's <head>
+            // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
+            document.head.appendChild(h('base', { href: ApiConfig.httpUnsafeOrigin }));
+
             cb(funcs);
         });
     } };


### PR DESCRIPTION
I believe that there used to be some event handlers for `<a>` tags in the sandbox which ensured that relative URLs were opened under the main/outer domain rather than the sandbox/inner one. This seems to have stopped working in one of the recent releases. I only noticed when I opened an old markdown document which used relative links between different pads.

I realized that this functionalty could be re-implemented much more simply by using a [`<base>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) tag. Adding such a tag with an `href` attribute pointing to the outer domain causes all relative links to be interpreted as relative to that URL, rather than to the sandbox (which is unlikely to be anyone's intended behaviour).

Types of URLs other than relative ones should not be affected, so I think this is unlikely to cause any new problems. That said, I haven't tested it very thoroughly except to confirm that relative links open in the expected context.

On a side note, a base tag is also a convenient way to define a global `target` behaviour, which could be relevant for #485.