### PR TITLE
Fix name of variable

### DIFF
--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -5,7 +5,7 @@
 "use strict";
 
 var config;
-var configPath = process.env.CRYPTPAD_CONFIG || "../config/config.js";
+var configPath = process.env.CPAD_CONF || "../config/config.js";
 try {
     config = require(configPath);
     if (config.adminEmail === 'i.did.not.read.my.config@cryptpad.fr') {


### PR DESCRIPTION
This is the only use of `CRYPTPAD_CONFIG` variable. In other files it's called `CPAD_CONF`.
[here](https://github.com/cryptpad/cryptpad/blob/main/docker-compose.yml#L14) and [here](https://github.com/cryptpad/cryptpad/blob/main/docker-entrypoint.sh#L10)