### PR TITLE
Reload server subprocesses after a configured number of tasks

### DIFF
--- a/lib/hk-util.js
+++ b/lib/hk-util.js
@@ -755,15 +755,16 @@ const handleGetHistoryRange = function (Env, Server, seq, userId, parsed) {
     var channelName = parsed[1];
     var map = parsed[2];
     const HISTORY_KEEPER_ID = Env.id;
+    const store = Env.store;
 
     if (!(map && typeof(map) === 'object')) {
         return void Server.send(userId, [seq, 'ERROR', 'INVALID_ARGS', HISTORY_KEEPER_ID]);
     }
 
-    var oldestKnownHash = map.from;
-    var untilHash = map.to;
-    var desiredMessages = map.count;
-    var desiredCheckpoint = map.cpCount;
+    var oldestKnownHash = map.from; // last known hash
+    var untilHash = map.to; // oldest hash (unknown), start point if defined
+    var desiredMessages = map.count; // nb messages before lkh
+    var desiredCheckpoint = map.cpCount; // nb cp before lkh
     var txid = map.txid;
     if (typeof(desiredMessages) !== 'number' && typeof(desiredCheckpoint) !== 'number' && !untilHash) {
         return void Server.send(userId, [seq, 'ERROR', 'UNSPECIFIED_COUNT', HISTORY_KEEPER_ID]);
@@ -774,6 +775,43 @@ const handleGetHistoryRange = function (Env, Server, seq, userId, parsed) {
     }
 
     Server.send(userId, [seq, 'ACK']);
+
+    if (untilHash) {
+        // Get all messages between untilHash (oldest but unknown)
+        // and oldestKnownHesh (last known hash) (or until the end if undefined)
+        // Messages can be streamed since we instantly know the start point
+        let found = false;
+        store.readMessagesBin(channelName, 0, (msgObj, readMore, abort) => {
+            const parsed = tryParse(Env, msgObj.buff.toString('utf8'));
+            if (!parsed) { return void readMore(); }
+            if (isMetadataMessage(parsed)) { return void readMore(); }
+            const content = parsed[4];
+            if (typeof(content) !== 'string') { return void readMore(); }
+
+            const hash = getHash(content);
+            if (hash === untilHash) { found = true; }
+            let then = hash === oldestKnownHash ? abort : readMore;
+            if (found) {
+                Server.send(userId, [0, HISTORY_KEEPER_ID, 'MSG', userId,
+                    JSON.stringify(['HISTORY_RANGE', txid, parsed])], then);
+            }
+            return void readMore();
+        }, function (err, reason) {
+            if (err) {
+                Env.Log.error("HK_GET_OLDER_HISTORY", channelName, err, reason);
+                Server.send(userId, [0, HISTORY_KEEPER_ID, 'MSG', userId,
+                    JSON.stringify(['HISTORY_RANGE_ERROR', txid, err])
+                ]);
+                return;
+            }
+            Server.send(userId, [0, HISTORY_KEEPER_ID, 'MSG', userId,
+                JSON.stringify(['HISTORY_RANGE_END', txid, channelName])
+            ]);
+        });
+        return;
+    }
+    // If desiredCp or desiredMsg are defined, we can't stream and must
+    // get a list of messages to send from a worker
     Env.getOlderHistory(channelName, oldestKnownHash, untilHash, desiredMessages, desiredCheckpoint, function (err, toSend) {
         if (err && err.code !== 'ENOENT') {
             Env.Log.error("HK_GET_OLDER_HISTORY", err);

--- a/lib/storage/file.js
+++ b/lib/storage/file.js
@@ -366,7 +366,7 @@ var readMessages = function (path, msgHandler, _cb) {
     return readFileBin(stream, function (msgObj, readMore) {
         collector.keepAlive();
         msgHandler(msgObj.buff.toString('utf8'));
-        readMore();
+        setTimeout(readMore);
     }, function (err) {
         cb(err);
     });

--- a/lib/workers/db-worker.js
+++ b/lib/workers/db-worker.js
@@ -40,7 +40,7 @@ Logger.levels.forEach(function (level) {
     };
 });
 
-const HISTORY_SIZE_LIMIT = 1024 * 1024 * 1024; // XXX 1GB
+//const HISTORY_SIZE_LIMIT = 1024 * 1024 * 1024; // XXX 1GB
 
 var DETAIL = 1000;
 var round = function (n) {
@@ -384,11 +384,50 @@ const getFileSize = function (data, cb) {
 
 const getOlderHistory = function (data, cb) {
     const oldestKnownHash = data.hash;
-    const untilHash = data.toHash;
     const channelName = data.channel;
     const desiredMessages = data.desiredMessages;
     const desiredCheckpoint = data.desiredCheckpoint;
 
+    let messages = [];
+    store.readMessagesBin(channelName, 0, (msgObj, readMore, abort) => {
+        const parsed = HK.tryParse(Env, msgObj.buff.toString('utf8'));
+        if (!parsed) { return void readMore(); }
+        if (HK.isMetadataMessage(parsed)) { return void readMore(); }
+        const content = parsed[4];
+        if (typeof(content) !== 'string') { return void readMore(); }
+        const hash = HK.getHash(content);
+
+        messages.push(parsed);
+
+        // "X" messages before oldestKnownHash
+        if (typeof (desiredMessages) === "number") {
+            messages = messages.slice(-desiredMessages);
+            if (hash === oldestKnownHash) { return void abort(); }
+            return void readMore();
+        }
+
+        // "X" checkpoints before oldestKnownHash
+        if (hash === oldestKnownHash) { return void abort(); }
+        if (/^cp\|/.test(content)) { // clean whenever we push a cp
+            let foundCp = 0;
+            const idx = messages.findLastIndex(parsed => {
+                let isCp = /^cp\|/.test(parsed[4]);
+                if (!isCp) { return; }
+                foundCp++;
+                return foundCp >= desiredCheckpoint;
+            });
+            if (idx > 0) {
+                messages = messages.slice(idx);
+            }
+        }
+        readMore();
+    }, function (err, reason) {
+        if (err) { return void cb(err, reason); }
+        cb(void 0, messages);
+    });
+
+    /*
+    const untilHash = data.toHash;
     var next = () => {
     var messages = [];
     var found = false;
@@ -444,6 +483,7 @@ const getOlderHistory = function (data, cb) {
         }
         next();
     });
+    */
 };
 
 const getPinState = function (data, cb) {

--- a/lib/workers/index.js
+++ b/lib/workers/index.js
@@ -52,8 +52,8 @@ Workers.initialize = function (Env, config, _cb) {
         //return Object.keys(workers[index].tasks || {}).length;
     };
 
-//    const WORKER_TASK_LIMIT = 100000;
-    const WORKER_TASK_LIMIT = 100; // XXX
+    const WORKER_TASK_LIMIT = 1000; // XXX
+    //const WORKER_TASK_LIMIT = 100; // XXX
 
     var workerOffset = -1;
     var queue = [];

--- a/lib/workers/index.js
+++ b/lib/workers/index.js
@@ -131,7 +131,7 @@ Workers.initialize = function (Env, config, _cb) {
         var cb = Util.once(Util.mkAsync(Util.both(_cb, function (err /*, value */) {
             incrementTime(msg && msg.command, start);
             if (err !== 'TIMEOUT') { return; }
-            Log.debug("WORKER_TIMEOUT_CAUSE", msg);
+            Log.warn("WORKER_TIMEOUT_CAUSE", msg);
             // in the event of a timeout the user will receive an error
             // but the state used to resend a query in the event of a worker crash
             // won't be cleared. This also leaks a slot that could be used to keep
@@ -268,7 +268,7 @@ Workers.initialize = function (Env, config, _cb) {
             // Create new
             state.complete = true;
             const w = fork(DB_PATH);
-            Log.debug('WORKER_REPLACE_START', {
+            Log.info('WORKER_REPLACE_START', {
                 from: state.worker.pid,
                 to: w.pid
             });
@@ -287,7 +287,7 @@ Workers.initialize = function (Env, config, _cb) {
             // Check remaining tasks
             if (Object.keys(state.tasks).length) { return; }
             // Kill
-            Log.debug('WORKER_KILL', {
+            Log.info('WORKER_KILL', {
                 worker: state.worker.pid,
                 count: state.count
             });

--- a/lib/workers/index.js
+++ b/lib/workers/index.js
@@ -52,16 +52,20 @@ Workers.initialize = function (Env, config, _cb) {
         //return Object.keys(workers[index].tasks || {}).length;
     };
 
+//    const WORKER_TASK_LIMIT = 100000;
+    const WORKER_TASK_LIMIT = 100; // XXX
+
     var workerOffset = -1;
     var queue = [];
-    var getAvailableWorkerIndex = function () {
+    var getAvailableWorkerIndex = function (isQueue) {
 //  If there is already a backlog of tasks you can avoid some work
-//  by going to the end of the line
-        if (queue.length) { return -1; }
+//  by going to the end of the line (unless we're trying to
+//  empty the queue)
+        if (queue.length && !isQueue) { return -1; }
 
         var L = workers.length;
         if (L === 0) {
-            Log.error('NO_WORKERS_AVAILABLE', {
+            Log.warn('NO_WORKERS_AVAILABLE', {
                 queue: queue.length,
             });
             return -1;
@@ -93,7 +97,7 @@ Workers.initialize = function (Env, config, _cb) {
     };
 
     var drained = true;
-    var sendCommand = function (msg, _cb, opt) {
+    var sendCommand = function (msg, _cb, opt, isQueue) {
         if (!_cb) {
             return void Log.error('WORKER_COMMAND_MISSING_CB', {
                 msg: msg,
@@ -102,7 +106,7 @@ Workers.initialize = function (Env, config, _cb) {
         }
 
         opt = opt || {};
-        var index = getAvailableWorkerIndex();
+        var index = getAvailableWorkerIndex(isQueue);
 
         var state = workers[index];
         // if there is no worker available:
@@ -114,7 +118,7 @@ Workers.initialize = function (Env, config, _cb) {
             });
             if (drained) {
                 drained = false;
-                Log.error('WORKER_QUEUE_BACKLOG', {
+                Log.warn('WORKER_QUEUE_BACKLOG', {
                     workers: workers.length,
                 });
             }
@@ -134,6 +138,7 @@ Workers.initialize = function (Env, config, _cb) {
             // an upper bound on the amount of parallelism for any given worker.
             // if you run out of slots then the worker locks up.
             delete state.tasks[txid];
+            state.checkTasks();
         })));
 
         if (!msg) {
@@ -164,6 +169,12 @@ Workers.initialize = function (Env, config, _cb) {
             msg._cb = _cb;
             msg._opt = opt;
         });
+
+        state.count++;
+        if (state.count > WORKER_TASK_LIMIT) {
+            // Remove from list and spawn new one
+            if (state.replaceWorker) { state.replaceWorker(); }
+        }
     };
 
     const pluginsResponses = {};
@@ -207,6 +218,8 @@ Workers.initialize = function (Env, config, _cb) {
         if (!res.txid) { return; }
         response.handle(res.txid, [res.error, res.value]);
         delete state.tasks[res.txid];
+        state.checkTasks();
+
         if (!queue.length) {
             if (!drained) {
                 drained = true;
@@ -234,7 +247,7 @@ Workers.initialize = function (Env, config, _cb) {
     to the back because the following msg took its place. OR, in an
     even worse scenario, we cycle through the queue but don't run anything.
 */
-        sendCommand(nextMsg.msg, nextMsg.cb);
+        sendCommand(nextMsg.msg, nextMsg.cb, {}, true);
     };
 
     const initWorker = function (worker, cb) {
@@ -243,13 +256,60 @@ Workers.initialize = function (Env, config, _cb) {
         const state = {
             worker: worker,
             tasks: {},
+            count: Math.floor(Math.random()*(WORKER_TASK_LIMIT/10)),
             pid: worker.pid, // store the child process's id in an easily accessible location
         };
+
+        state.replaceWorker = () => {
+            let index = workers.indexOf(state);
+            if (index === -1) { return; }
+            // Remove old
+            workers.splice(index, 1);
+            // Create new
+            state.complete = true;
+            const w = fork(DB_PATH);
+            Log.debug('WORKER_REPLACE_START', {
+                from: state.worker.pid,
+                to: w.pid
+            });
+            initWorker(w, function (err) {
+                if (err) {
+                    throw new Error(err);
+                }
+            });
+        };
+
+        // If we've reached the limit, kill the worker once
+        // all the tasks are complete or timed out
+        state.checkTasks = () => {
+            // Check limit
+            if (!state.complete || !state.worker) { return; }
+            // Check remaining tasks
+            if (Object.keys(state.tasks).length) { return; }
+            // Kill
+            Log.debug('WORKER_KILL', {
+                worker: state.worker.pid,
+                count: state.count
+            });
+            delete state.worker;
+            worker.kill();
+        }
 
         response.expect(txid, function (err) {
             if (err) { return void cb(err); }
             workers.push(state);
             cb(void 0, state);
+            // We just pushed a new worker, available to receive
+            // a task, so we can empty the queue if necessary
+            if (queue.length) {
+                const nextMsg = queue.shift();
+                if (!nextMsg || !nextMsg.msg) {
+                    return Log.error('WORKER_QUEUE_EMPTY_MESSAGE', {
+                        item: nextMsg,
+                    });
+                }
+                sendCommand(nextMsg.msg, nextMsg.cb, {}, true);
+            }
         }, 15000);
 
         worker.send({
@@ -296,18 +356,21 @@ Workers.initialize = function (Env, config, _cb) {
         });
 
         worker.on('exit', function () {
+            if (!state.worker) { return; } // Manually killed
             substituteWorker();
             Env.Log.error("DB_WORKER_EXIT", {
                 pid: state.pid,
             });
         });
         worker.on('close', function () {
+            if (!state.worker) { return; } // Manually killed
             substituteWorker();
             Env.Log.error("DB_WORKER_CLOSE", {
                 pid: state.pid,
             });
         });
         worker.on('error', function (err) {
+            if (!state.worker) { return; } // Manually killed
             substituteWorker();
             Env.Log.error("DB_WORKER_ERROR", {
                 pid: state.pid,

--- a/lib/workers/index.js
+++ b/lib/workers/index.js
@@ -293,7 +293,7 @@ Workers.initialize = function (Env, config, _cb) {
             });
             delete state.worker;
             worker.kill();
-        }
+        };
 
         response.expect(txid, function (err) {
             if (err) { return void cb(err); }


### PR DESCRIPTION
* this would be a workaround against a small memory leak
* includes the fixes about server memory related to document history