### PR TITLE
Translations update from CryptPad Translations

### DIFF
--- a/www/common/translations/messages.de.json
+++ b/www/common/translations/messages.de.json
@@ -1817,5 +1817,6 @@
     "admin_logoSize_error": "Das Logo ist zu groß",
     "addItemBottom": "Karte am Ende des Boards hinzufügen",
     "kanban_moveBoardRight": "Board nach rechts verschieben",
-    "admin_listConfirm": "Bist du sicher, dass du die Admin-Rechte dieses Benutzers entfernen möchtest?"
+    "admin_listConfirm": "Bist du sicher, dass du die Admin-Rechte dieses Benutzers entfernen möchtest?",
+    "profile_remove_avatar": "Diesen Avatar entfernen"
 }

--- a/www/common/translations/messages.pl.json
+++ b/www/common/translations/messages.pl.json
@@ -773,7 +773,7 @@
     "form_totalResponses": "Całkowita liczba odpowiedzi: {0}",
     "ui_expand": "Rozwiń",
     "ui_collapse": "Zwiń",
-    "fm_link_invalid": "Nieprawidłowy adres URL",
+    "fm_link_invalid": "Wprowadź poprawny adres URL",
     "fm_link_warning": "Ostrzeżenie: adres URL przekracza 200 znaków",
     "form_answerAs": "Odpowiedz jako",
     "form_anonName": "Twoje imię",
@@ -907,7 +907,7 @@
     "calendar_dateRange": "{0} - {1}",
     "calendar_newEvent": "Nowe wydarzenie",
     "calendar_import": "Dodaj do moich kalendarzy",
-    "calendar_errorNoCalendar": "Nie wybrano kalendarza, który można edytować",
+    "calendar_errorNoCalendar": "Nie wybrano kalendarza",
     "calendar_deleteOwned": "Pozostanie on widoczny dla innych użytkowników, którym został udostępniony.",
     "calendar_deleteTeamConfirm": "Czy na pewno chcesz usunąć ten kalendarz z zespołu?",
     "calendar_deleteConfirm": "Czy na pewno chcesz usunąć ten kalendarz ze swojego konta?",
@@ -1785,7 +1785,7 @@
     "admin_mfa_confirm_enable": "Czy na pewno chcesz włączyć uwierzytelnianie wieloetapowe?",
     "admin_mfa_confirm_disable": "Czy na pewno chcesz wyłączyć uwierzytelnianie wieloetapowe?",
     "form_passwordWarning": "Zwróć uwagę, że hasło do formularza można ustawić tylko teraz, podczas tworzenia go, i nie może być ono zmienione później.",
-    "fm_restoreMultipleDialog": "Czy na pewni chcesz przywrócić {0} plików i/lub folderów do ich poprzedniej lokalizacji?",
+    "fm_restoreMultipleDialog": "Czy na pewno chcesz przywrócić {0} plików i/lub folderów do ich poprzedniej lokalizacji?",
     "calendar_show": "Pokaż kalendarze",
     "calendar_hide": "Ukryj kalendarze",
     "admin_logoSize_error": "Rozmiar logo jest zbyt duży",
@@ -1817,5 +1817,6 @@
     "admin_errorAddAdmins": "Wybierz kontakt, aby nadać im uprawnienia administratorów",
     "admin_listHardcoded": "Administrator dodany do pliku config.js. Może być usunięty tylko poprzez edycję pliku.",
     "addItemBottom": "Dodaj kartę do spodu tablicy",
-    "toggleArrows": "Przesuń elementy za pomocą strzałek"
+    "toggleArrows": "Przesuń elementy za pomocą strzałek",
+    "profile_remove_avatar": "Usuń ten awatar"
 }

--- a/www/common/translations/messages.zh.json
+++ b/www/common/translations/messages.zh.json
@@ -1817,5 +1817,6 @@
     "toggleArrows": "箭头按钮移动项目",
     "toggleDrag": "拖动移动项目",
     "error_limit": "请输入有效数字",
-    "admin_addKeyLabel": "使用管理员的公钥添加管理员"
+    "admin_addKeyLabel": "使用管理员的公钥添加管理员",
+    "profile_remove_avatar": "移除此头像"
 }


### PR DESCRIPTION
Translations update from [CryptPad Translations](https://weblate.cryptpad.org) for [CryptPad/App](https://weblate.cryptpad.org/projects/cryptpad/app/).



Current translation status:

![Weblate translation status](https://weblate.cryptpad.org/widget/cryptpad/app/horizontal-auto.svg)