### PR TITLE
Improve Kanban Tags accessibility with keyboard navigation

### DIFF
--- a/www/kanban/app-kanban.less
+++ b/www/kanban/app-kanban.less
@@ -515,6 +515,9 @@
                         background-color: @cp_kanban-fg;
                         color: @cp_kanban-item-bg;
                     }
+                    &:focus-visible {
+                        outline: @variables_focus_style;
+                    }
                 }
             }
         }

--- a/www/kanban/inner.js
+++ b/www/kanban/inner.js
@@ -1153,11 +1153,6 @@ define([
                         'data-tag': t,
                         'tabindex': 0
                     }, t));
-                    $(tag).keydown(function (e) {
-                        if (e.which === 13 || e.which === 32) {
-                            $(tag).click();
-                        }
-                    });
                     var $tag = $(tag).click(function () {
                         if ($tag.hasClass('active')) {
                             $tag.removeClass('active');
@@ -1165,6 +1160,10 @@ define([
                             $tag.addClass('active');
                         }
                         commitTags();
+                    }).keydown(function (e) {
+                        if (e.which === 13 || e.which === 32) {
+                            $tag.click();
+                        }
                     });
                 });
             };

--- a/www/kanban/inner.js
+++ b/www/kanban/inner.js
@@ -1151,13 +1151,17 @@ define([
                     var tag;
                     $list.append(tag = h('span', {
                         'data-tag': t,
-                        'tabindex': 0
+                        'tabindex': 0,
+                        'role': 'button',
+                        'aria-pressed': 'false'
                     }, t));
                     var $tag = $(tag).click(function () {
                         if ($tag.hasClass('active')) {
                             $tag.removeClass('active');
+                            $tag.attr('aria-pressed', 'false');
                         } else {
                             $tag.addClass('active');
+                            $tag.attr('aria-pressed', 'true');
                         }
                         commitTags();
                     }).keydown(function (e) {
@@ -1191,7 +1195,7 @@ define([
                 commitTags();
             });
 
-            let toggleTagsButton = h('button.btn.btn-toolbar-alt.cp-kanban-toggle-tags', [
+            let toggleTagsButton = h('button.btn.btn-toolbar-alt.cp-kanban-toggle-tags', {'aria-expanded': 'true'}, [
                 h('i.fa.fa-tags'),
                 h('span', Messages.fm_tagsName)
             ]);
@@ -1203,6 +1207,7 @@ define([
             let toggle = () => {
                 $tags.toggle();
                 let visible = $tags.is(':visible');
+                $toggleBtn.attr('aria-expanded', visible.toString());
                 $(toggleContainer).toggleClass('cp-kanban-container-flex', !visible);
                 $toggleBtn.toggleClass('btn-toolbar-alt', visible);
                 $toggleBtn.toggleClass('btn-toolbar', !visible);

--- a/www/kanban/inner.js
+++ b/www/kanban/inner.js
@@ -1150,8 +1150,14 @@ define([
                 allTags.forEach(function (t) {
                     var tag;
                     $list.append(tag = h('span', {
-                        'data-tag': t
+                        'data-tag': t,
+                        'tabindex': 0
                     }, t));
+                    $(tag).keydown(function (e) {
+                        if (e.which === 13 || e.which === 32) {
+                            $(tag).click();
+                        }
+                    });
                     var $tag = $(tag).click(function () {
                         if ($tag.hasClass('active')) {
                             $tag.removeClass('active');


### PR DESCRIPTION
This PR addresses the Kanban tags and resolves the issue by making them accessible via keyboard, closing #1809.