### PR TITLE
Add forceRedirect to SSO

### DIFF
--- a/config/sso.example.js
+++ b/config/sso.example.js
@@ -12,6 +12,8 @@ module.exports = {
     cpPassword: false,
     // You can also force your SSO users to add a CryptPad password
     forceCpPassword: false,
+    // Force redirect to first SSO provider
+    forceRedirect: true,
     // List of SSO providers
     list: [
     /*

--- a/customize.dist/pages/login.js
+++ b/customize.dist/pages/login.js
@@ -14,7 +14,9 @@ define([
 
         var ssoEnabled = (Config.sso && Config.sso.list && Config.sso.list.length) ?'': '.cp-hidden';
         var ssoEnforced = (Config.sso && Config.sso.force) ? '.cp-hidden' : '';
-
+        if (Config.sso && Config.sso.list && Config.sso.forceRedirect === 1) {
+            return;
+        }   
         return [h('div#cp-main', [
             Pages.infopageTopbar(),
             h('div.container.cp-container', [

--- a/lib/http-worker.js
+++ b/lib/http-worker.js
@@ -595,6 +595,7 @@ var serveConfig = makeRouteCache(function () {
                     Env.sso.list.map(function (obj) { return obj.name; }) || [];
     const ssoCfg = (SSOUtils && ssoList.length) ? {
         force: (Env.sso && Env.sso.enforced && 1) || 0,
+        forceRedirect: (Env.sso && Env.sso.forceRedirect && 1) || 0,
         password: (Env.sso && Env.sso.cpPassword && (Env.sso.forceCpPassword ? 2 : 1)) || 0,
         list: ssoList
     } : false;

--- a/www/login/main.js
+++ b/www/login/main.js
@@ -31,6 +31,17 @@ define([
             // Config.sso.password => cp password required or forbidden
             // Config.sso.list => list of configured identity providers
             var $sso = $('div.cp-login-sso');
+            // Auto-redirect if only one SSO provider is configured
+            if (Config.sso && Config.sso.list && Config.sso.forceRedirect === 1) {
+                Login.ssoAuth(Config.sso.list[0], function (err, data) {
+                    if (data && data.url) {
+                        window.location.href = data.url;
+                    } else {
+                        console.error("SSO auto-redirect failed:", err || "no URL");
+                    }
+                });
+                return;
+            }
             var list = Config.sso.list.map(function (name) {
                 var b = h('button.btn.btn-secondary', name);
                 var $b = $(b).click(function () {


### PR DESCRIPTION
**Add forceRedirect Support for SSO Login**
This PR introduces a new forceRedirect configuration option under the SSO settings. When enabled and only one SSO provider is configured, users are automatically redirected to the provider’s login flow — skipping the intermediate login screen.

Changes Made

- Added a new forceRedirect boolean flag in the server-side SSO config.
- Ensured forceRedirect is passed to the frontend (Config.sso.forceRedirect).
- Implemented auto-redirect logic in the login screen when:
   - SSO is enabled,
   - And forceRedirect === true.
   It resolves the issue mentioned here: https://github.com/cryptpad/cryptpad/issues/1862
   ```
       sso: {
      enabled: true,
      enforced: true,
      forceRedirect: true,
      list: ['keycloak']
    }

```