### PR TITLE
Fix mobile scrolling within kanban columns in arrow-buttons mode

### DIFF
--- a/www/kanban/app-kanban.less
+++ b/www/kanban/app-kanban.less
@@ -241,8 +241,8 @@
         background: @cp_kanban-item-bg;
         box-shadow: @cryptpad_ui_shadow;
         .tools_unselectable();
-        touch-action: none;
         &:not(.no-drag) {
+            touch-action: none;
             cursor: move;
             cursor: grab;
         }


### PR DESCRIPTION
Setting `touch-action: none;` on kanban items isn't necessary when dragging is disabled, and it interferes with tapping and dragging to scroll columns. On Android Firefox, Android Chromium, and Linux Firefox in responsive-design mode with touch simulation, I'm finding that after drag-scrolling a column in arrow-buttons mode, there's a 15-second cooldown before I'm able to scroll it again (unless I very carefully aim my finger for the gap between kanban items where the `touch-action: none;` rule isn't applied).