### PR TITLE
Update Mastodon instance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ Note that every GitHub release page has an RSS compatible feed that you can subs
 We do also communicate about this topic on:
 - [Our blog](https://blog.cryptpad.org)
 - [Our Matrix public space](https://matrix.to/#/#cryptpad:matrix.xwiki.com)
-- [Our Mastodon account](https://fosstodon.org/@cryptpad)
+- [Our Mastodon account](https://social.xwiki.com/@CryptPad)
 
 ## Reporting a Vulnerability
 

--- a/customize.dist/pages/contact.js
+++ b/customize.dist/pages/contact.js
@@ -79,7 +79,7 @@ define([
                         )
                     ),
                     h('div',
-                        h('a.card-small', {href : "https://fosstodon.org/@cryptpad"},
+                        h('a.card-small', {href : "https://social.xwiki.com/@CryptPad"},
                             h('div.card-body',
                                 h('p', [
                                     h('img', {

--- a/readme.md
+++ b/readme.md
@@ -80,7 +80,7 @@ More information about this can be found in [our translation guide](/customize.d
 
 The best places to reach the development team and the community are the [CryptPad Forum](https://forum.cryptpad.org) and the [Matrix chat](https://matrix.to/#/#cryptpad:matrix.xwiki.com)
 
-The team is also on the fediverse: [@cryptpad@fosstodon.org](https://fosstodon.org/@cryptpad)
+The team is also on the fediverse: [@cryptpad@xwiki.com](https://social.xwiki.com/@CryptPad)
 
 # Team
 


### PR DESCRIPTION
Following our move from Fosstodon to the new XWiki self-hosted mastodon instance, I have updated all links to point to our new account.