### PR TITLE
fix typo in shebang of rc.d-cryptpad

### DIFF
--- a/docs/rc.d-cryptpad
+++ b/docs/rc.d-cryptpad
@@ -1,4 +1,4 @@
-!/bin/sh
+#!/bin/sh
 # $FreeBSD$
 # PROVIDE: cryptpad
 # REQUIRE: DAEMON nginx


### PR DESCRIPTION
missing # in shebang