### PR TITLE
Natural sort inconsistent behaviour fix

### DIFF
--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -3460,19 +3460,23 @@ define([
                 b = [b];
             }
 
-            if(a.length === 0 && b.length === 0) {
+            if (a.length === 0 && b.length === 0) {
                 return 0;
             } else if (a.length === 0) {
                 return -1;
             } else if (b.length === 0) {
                 return 1;
-            } else if(a[0] < b[0]) {
-                return -1;
-            } else if(a[0] > b[0]) {
-                return 1;
+            } else if (typeof (a[0]) !== typeof (b[0])) {
+                return String(a[0]) < String(b[0]) ? -1 : 1;
             } else {
-                // This means `a[0] == b[0]`. Chop off the first elements and compare the rest.
-                return lexicographicCompare(a.slice(1), b.slice(1));
+                if (a[0] < b[0]) {
+                    return -1;
+                } else if (a[0] > b[0]) {
+                    return 1;
+                } else {
+                    // This means `a[0] == b[0]`. Chop off the first elements and compare the rest.
+                    return lexicographicCompare(a.slice(1), b.slice(1));
+                }
             }
         };
 


### PR DESCRIPTION
This PR fixes some inconsistent sorts that appeared with #1739 

Before:
![before](https://github.com/user-attachments/assets/5023ec7a-ae1f-4392-8e75-480e16176beb)

With this PR:
![after](https://github.com/user-attachments/assets/c479c3e3-ab24-4fc1-9078-920b7875bd59)

The issue spanned from the comparison between `int` and `string` that was not behaving as expected.