### PR TITLE
 Improve keyboard navigation & screen reader support for "Create New Document" modal

### DIFF
--- a/customize.dist/messages.js
+++ b/customize.dist/messages.js
@@ -143,6 +143,8 @@ define(req, function(AppConfig, Default, Language) {
     Messages.add_password = "Add your document password";
     Messages.show_password = "Show password";
     Messages.hide_password = "Hide password";
+    Messages.next_templateList = "Next template list";
+    Messages.previous_templateList = "Previous template list";
     return Messages;
 
 });

--- a/customize.dist/messages.js
+++ b/customize.dist/messages.js
@@ -140,6 +140,9 @@ define(req, function(AppConfig, Default, Language) {
     Messages.badges_premium = "Premium user";
     Messages.badges_error = "Error while validating this user's data";
     Messages.profile_badges = "Badges";
+    Messages.add_password = "Add your document password";
+    Messages.show_password = "Show password";
+    Messages.hide_password = "Hide password";
     return Messages;
 
 });

--- a/customize.dist/src/less2/include/creation.less
+++ b/customize.dist/src/less2/include/creation.less
@@ -327,6 +327,7 @@
                     text-align: center;
                     background-color: transparent;
                     border-color: transparent;
+                    color: @cryptpad_text_col;
                     &:first-child {
                         left: 5px;
                     }

--- a/customize.dist/src/less2/include/creation.less
+++ b/customize.dist/src/less2/include/creation.less
@@ -328,6 +328,7 @@
                     background-color: transparent;
                     border-color: transparent;
                     color: @cryptpad_text_col;
+                    border-radius: @variables_radius;
                     &:first-child {
                         left: 5px;
                     }

--- a/customize.dist/src/less2/include/creation.less
+++ b/customize.dist/src/less2/include/creation.less
@@ -323,9 +323,10 @@
                 justify-content: space-between;
                 .cp-creation-template-more {
                     font-size: 30px;
-                    cursor: pointer;
                     margin: 0 5px;
                     text-align: center;
+                    background-color: transparent;
+                    border-color: transparent;
                     &:first-child {
                         left: 5px;
                     }

--- a/customize.dist/src/less2/include/creation.less
+++ b/customize.dist/src/less2/include/creation.less
@@ -32,6 +32,11 @@
 & {
     .creation_vars();
 
+    &:focus-visible {
+        outline: @variables_focus_style;
+        border-radius: @variables_radius;
+    }
+
     #cp-creation-container {
         position: absolute;
         z-index: 100000000; // #loading * 10
@@ -122,6 +127,9 @@
                     font-size: 16px;
                     color: inherit;
                 }
+                a:focus-visible {
+                    border-radius: 50%;
+                }
             }
         }
         .cp-creation-early {
@@ -142,9 +150,8 @@
                 border: none;
                 border-radius: @variables_radius;
                 cursor: pointer;
-                outline: none;
                 text-transform: uppercase;
-                &:hover {
+                &:hover, &:focus-visible {
                     background: contrast(@cp_creation-button-fg, lighten(@cp_creation-button-bg, 5%), darken(@cp_creation-button-bg, 5%));
                 }
             }
@@ -186,12 +193,13 @@
                 }
             }
             .cp-creation-slider {
-                display: block;
+                display: none;
                 overflow: hidden;
                 max-height: 0px;
                 max-width: 0px;
                 //margin-top: 10px;
                 &.active {
+                    display: block;
                     transition: max-height 0.5s ease-in-out;
                     max-width: none;
                     max-height: 100px;
@@ -259,13 +267,11 @@
                     input {
                         width: 45px;
                         margin: 0 5px;
-                        padding: 0;
-                        padding-left: 3px;
-                        margin: 0 5px;
+                        padding: 0 0 0 3px;
                     }
                     select {
-                        margin-right: 5px;
                         border-radius: @variables_radius;
+                        margin: 0.2rem;
                     }
                 }
                 &.active {
@@ -286,9 +292,13 @@
                         input {
                             width: 150px;
                             padding: 0 5px;
+                            margin: 0.2rem;
                         }
                         label {
                             flex: none;
+                        }
+                        .cp-password-reveal {
+                            margin:0.2rem;
                         }
                     }
                 }

--- a/customize.dist/src/less2/include/creation.less
+++ b/customize.dist/src/less2/include/creation.less
@@ -32,12 +32,12 @@
 & {
     .creation_vars();
 
-    &:focus-visible {
-        outline: @variables_focus_style;
-        border-radius: @variables_radius;
-    }
-
     #cp-creation-container {
+        &:focus-visible {
+            outline: @variables_focus_style;
+            border-radius: @variables_radius;
+        }
+
         position: absolute;
         z-index: 100000000; // #loading * 10
         top: 0px;

--- a/customize.dist/src/less2/include/loading.less
+++ b/customize.dist/src/less2/include/loading.less
@@ -126,13 +126,14 @@
         .cp-password-form {
             display: flex;
             flex-wrap: wrap;
+            gap:0.5rem;
             width: 100%;
             .cp-password-container {
                 flex-shrink: 1;
                 min-width: 0;
             }
             .cp-password-reveal {
-                padding: 0px 24px;
+                margin-left: 0.5rem;
             }
         }
         .cp-password-input {

--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -1040,7 +1040,7 @@ define([
             href: href,
             target: "_blank",
             'data-tippy-placement': "right",
-            'aria-label': tex
+            'aria-label': text
         });
         return q;
     };

--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -986,11 +986,15 @@ define([
             type: 'password',
             tabindex: '0',
             autocomplete: 'one-time-code', // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values
+            'aria-label': 'Enter your document password', // XXX
         }, opts);
 
         var input = h('input.cp-password-input', attributes);
         var eye = h('span.fa.fa-eye.cp-password-reveal', {
-            tabindex: 0
+            tabindex: 0,
+            role: 'button',
+            'aria-label': 'Show password', // XXX
+            'aria-pressed': 'false'
         });
 
         var $eye = $(eye);
@@ -1013,12 +1017,12 @@ define([
                 if ($eye.hasClass('fa-eye')) {
                     $input.prop('type', 'text');
                     $input.focus();
-                    $eye.removeClass('fa-eye').addClass('fa-eye-slash');
+                    $eye.removeClass('fa-eye').addClass('fa-eye-slash').attr('aria-label', 'Hide password').attr('aria-pressed', 'true'); // XXX
                     return;
                 }
                 $input.prop('type', 'password');
                 $input.focus();
-                $eye.removeClass('fa-eye-slash').addClass('fa-eye');
+                $eye.removeClass('fa-eye-slash').addClass('fa-eye').attr('aria-label', 'Show password').attr('aria-pressed', 'false'); // XXX
             });
         }
 
@@ -1036,7 +1040,7 @@ define([
             href: href,
             target: "_blank",
             'data-tippy-placement': "right",
-            'aria-label': Messages.help_genericMore //TBC XXX
+            'aria-label': text
         });
         return q;
     };
@@ -1353,13 +1357,12 @@ define([
         });
 
         $input.change(function () {
+            $mark.attr('aria-checked', $input.is(':checked'));
             if (!opts.labelAlt) { return; }
             if ($input.is(':checked') !== checked) {
                 $(label).text(opts.labelAlt);
-                $mark.attr('aria-checked', 'true');
             } else {
                 $(label).text(labelTxt);
-                $mark.attr('aria-checked', 'false');
             }
         });
 

--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -986,7 +986,6 @@ define([
             type: 'password',
             tabindex: '0',
             autocomplete: 'one-time-code', // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values
-            'aria-label': Messages.add_password
         }, opts);
 
         var input = h('input.cp-password-input', attributes);

--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -986,14 +986,14 @@ define([
             type: 'password',
             tabindex: '0',
             autocomplete: 'one-time-code', // https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values
-            'aria-label': 'Enter your document password', // XXX
+            'aria-label': Messages.add_password
         }, opts);
 
         var input = h('input.cp-password-input', attributes);
         var eye = h('span.fa.fa-eye.cp-password-reveal', {
             tabindex: 0,
             role: 'button',
-            'aria-label': 'Show password', // XXX
+            'aria-label': Messages.show_password,
             'aria-pressed': 'false'
         });
 
@@ -1017,12 +1017,12 @@ define([
                 if ($eye.hasClass('fa-eye')) {
                     $input.prop('type', 'text');
                     $input.focus();
-                    $eye.removeClass('fa-eye').addClass('fa-eye-slash').attr('aria-label', 'Hide password').attr('aria-pressed', 'true'); // XXX
+                    $eye.removeClass('fa-eye').addClass('fa-eye-slash').attr('aria-label', Messages.hide_password).attr('aria-pressed', 'true');
                     return;
                 }
                 $input.prop('type', 'password');
                 $input.focus();
-                $eye.removeClass('fa-eye-slash').addClass('fa-eye').attr('aria-label', 'Show password').attr('aria-pressed', 'false'); // XXX
+                $eye.removeClass('fa-eye-slash').addClass('fa-eye').attr('aria-label', Messages.show_password).attr('aria-pressed', 'false');
             });
         }
 
@@ -1040,7 +1040,7 @@ define([
             href: href,
             target: "_blank",
             'data-tippy-placement': "right",
-            'aria-label': text
+            'aria-label': tex
         });
         return q;
     };

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2793,14 +2793,10 @@ define([
         var $w = $(window);
         var big = $w.width() > 800;
 
-        var right = h('span.fa.fa-chevron-right.cp-creation-template-more', {
-            tabindex: 0,
-            role: 'button',
+        var right = h('button.fa.fa-chevron-right.cp-creation-template-more', {
             'aria-label': Messages.next_templateList
         });
-        var left = h('span.fa.fa-chevron-left.cp-creation-template-more', {
-            tabindex: 0,
-            role: 'button',
+        var left = h('button.fa.fa-chevron-left.cp-creation-template-more', {
             'aria-label': Messages.previous_templateList
         });
         if (!big) {

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2782,7 +2782,7 @@ define([
         var password = h('div.cp-creation-password',  [ 
             UI.createCheckbox('cp-creation-password', Messages.properties_addPassword, false),
             h('span.cp-creation-password-picker.cp-creation-slider', [
-                UI.passwordInput({id: 'cp-creation-password-val'})
+                UI.passwordInput({id: 'cp-creation-password-val', placeholder: Messages.add_password})
                 /*h('input#cp-creation-password-val', {
                     type: "text" // TODO type password with click to show
                 }),*/

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2652,7 +2652,7 @@ define([
         var logo = h('img', { src: '/customize/CryptPad_logo.svg?' + urlArgs });
         var fill1 = h('div.cp-creation-fill.cp-creation-logo',{ role: 'presentation' }, logo);
         var fill2 = h('div.cp-creation-fill');
-        var $creation = $('<div>', { id: 'cp-creation', tabindex:1 });
+        var $creation = $('<div>', { id: 'cp-creation' });
         $creationContainer.append([fill1, $creation, fill2]);
 
         var createHelper = function (href, text) {
@@ -2865,10 +2865,17 @@ define([
                     var $span = $('<span>', {
                         'class': 'cp-creation-template-element',
                         'title': name,
+                        'aria-label': name,
+                        'tabindex': 0,
+                        'role':'radio',
+                        'aria-checked': false,
                     }).appendTo($container);
                     $span.data('id', obj.id);
                     if (obj.content) { $span.data('content', obj.content); }
-                    if (idx === selected) { $span.addClass('cp-creation-template-selected'); }
+                    if (idx === selected) {
+                        $span.addClass('cp-creation-template-selected');
+                        $span.attr('aria-checked', true);
+                    }
                     if (!obj.thumbnail) {
                         $span.append(obj.icon || h('span.cptools.cptools-template'));
                     }
@@ -2876,8 +2883,9 @@ define([
                         .appendTo($span);
                     $span.click(function () {
                         $container.find('.cp-creation-template-selected')
-                            .removeClass('cp-creation-template-selected');
+                            .removeClass('cp-creation-template-selected').attr('aria-checked', 'false');
                         $span.addClass('cp-creation-template-selected');
+                        $span.attr('aria-checked', true);
                         selected = idx;
                     });
 
@@ -3075,19 +3083,20 @@ define([
             create();
         });
 
-        $creation.keydown(function (e) {
-            if (e.which === 9) {
-                e.preventDefault();
-                e.stopPropagation();
-                next(e.shiftKey);
-                return;
-            }
-            if (e.which === 13) {
-                $button.click();
-                return;
-            }
-        });
-        $creation.focus();
+        // $creation.keydown(function (e) {
+        //     if (e.which === 9) {
+        //         e.preventDefault();
+        //         e.stopPropagation();
+        //         next(e.shiftKey);
+        //         return;
+        //     }
+        //     if (e.which === 13) {
+        //         $button.click();
+        //         return;
+        //     }
+        // }
+        // $creation.focus();
+        UI.addTabListener($creation);
     };
 
     UIElements.loginErrorScreenContent = function (common) {

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2793,8 +2793,16 @@ define([
         var $w = $(window);
         var big = $w.width() > 800;
 
-        var right = h('span.fa.fa-chevron-right.cp-creation-template-more');
-        var left = h('span.fa.fa-chevron-left.cp-creation-template-more');
+        var right = h('span.fa.fa-chevron-right.cp-creation-template-more', {
+            tabindex: 0,
+            role: 'button',
+            'aria-label': Messages.next_templateList
+        });
+        var left = h('span.fa.fa-chevron-left.cp-creation-template-more', {
+            tabindex: 0,
+            role: 'button',
+            'aria-label': Messages.previous_templateList
+        });
         if (!big) {
             $(left).removeClass('fa-chevron-left').addClass('fa-chevron-up');
             $(right).removeClass('fa-chevron-right').addClass('fa-chevron-down');
@@ -2881,7 +2889,7 @@ define([
                     }
                     $('<span>', {'class': 'cp-creation-template-element-name'}).text(name)
                         .appendTo($span);
-                    $span.click(function () {
+                    Util.onClickEnter($span, function () {
                         $container.find('.cp-creation-template-selected')
                             .removeClass('cp-creation-template-selected').attr('aria-checked', 'false');
                         $span.addClass('cp-creation-template-selected');
@@ -2897,11 +2905,13 @@ define([
                 $(right).off('click').removeClass('hidden').click(function () {
                     selected = 0;
                     redraw(i + TEMPLATES_DISPLAYED);
+                    $('.cp-creation-template-container').find('[tabindex]:not([tabindex="-1"])').filter(':visible').first().focus();
                 });
                 if (i >= allData.length - TEMPLATES_DISPLAYED ) { $(right).addClass('hidden'); }
                 $(left).off('click').removeClass('hidden').click(function () {
                     selected = TEMPLATES_DISPLAYED - 1;
                     redraw(i - TEMPLATES_DISPLAYED);
+                    $('.cp-creation-template-container').find('[tabindex]:not([tabindex="-1"])').filter(':visible').first().focus();
                 });
                 if (i < TEMPLATES_DISPLAYED) { $(left).addClass('hidden'); }
             };

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2649,7 +2649,7 @@ define([
         var $creationContainer = $('<div>', { id: 'cp-creation-container' }).appendTo($body);
         var urlArgs = (Config.requireConf && Config.requireConf.urlArgs) || '';
 
-        var logo = h('img', { src: '/customize/CryptPad_logo.svg?' + urlArgs });
+        var logo = h('img', { src: '/customize/CryptPad_logo.svg?' + urlArgs, alt:'', 'aria-hidden': 'true' });
         var fill1 = h('div.cp-creation-fill.cp-creation-logo',{ role: 'presentation' }, logo);
         var fill2 = h('div.cp-creation-fill');
         var $creation = $('<div>', { id: 'cp-creation' });

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3082,6 +3082,7 @@ define([
         });
 
         UI.addTabListener($creation);
+        $button.focus();
     };
 
     UIElements.loginErrorScreenContent = function (common) {

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2980,7 +2980,6 @@ define([
             }
             $creation.find('.cp-creation-expire-picker').removeClass('active');
             $creation.find('.cp-creation-expire').removeClass('active');
-            $creation.focus();
         });
 
         // Display password form when checkbox checked
@@ -2993,7 +2992,6 @@ define([
             }
             $creation.find('.cp-creation-password-picker').removeClass('active');
             $creation.find('.cp-creation-password').removeClass('active');
-            $creation.focus();
         });
 
         // Keyboard shortcuts
@@ -3083,19 +3081,6 @@ define([
             create();
         });
 
-        // $creation.keydown(function (e) {
-        //     if (e.which === 9) {
-        //         e.preventDefault();
-        //         e.stopPropagation();
-        //         next(e.shiftKey);
-        //         return;
-        //     }
-        //     if (e.which === 13) {
-        //         $button.click();
-        //         return;
-        //     }
-        // }
-        // $creation.focus();
         UI.addTabListener($creation);
     };
 

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2649,8 +2649,8 @@ define([
         var $creationContainer = $('<div>', { id: 'cp-creation-container' }).appendTo($body);
         var urlArgs = (Config.requireConf && Config.requireConf.urlArgs) || '';
 
-        var logo = h('img', { src: '/customize/CryptPad_logo.svg?' + urlArgs, alt:'', 'aria-hidden': 'true' });
-        var fill1 = h('div.cp-creation-fill.cp-creation-logo',{ role: 'presentation' }, logo);
+        var logo = h('img', { src: '/customize/CryptPad_logo.svg?' + urlArgs, alt:'', 'aria-hidden': 'true',role: 'presentation' });
+        var fill1 = h('div.cp-creation-fill.cp-creation-logo', logo);
         var fill2 = h('div.cp-creation-fill');
         var $creation = $('<div>', { id: 'cp-creation' });
         $creationContainer.append([fill1, $creation, fill2]);


### PR DESCRIPTION
This PR fixes the user scenario for creating a new document by addressing accessibility issues in the "Create New Document" modal. Keyboard users and screen reader users couldn't interact with the page effectively: focus didn’t move correctly, some elements trapped the keyboard, and screen readers couldn’t read the modal content.

This PR includes the following fixes:
- ensure there are no keyboard traps
- enable proper keyboard navigation across all focusable elements
- add visual focus outline
-  improve screen reader support:
     -  add proper aria roles to elements
     - update aria-label

Closes #1912 
Tested with NVDA, AxeCore

Note: I changed the merging branch because changes from this PR are connected with #1913. The other PR depends on the changes introduced here, so this PR is ready for review and should be merged first. Testing of the full flow will be completed once both PRs are merged.