### PR TITLE
Improve screen reader support for Document access

### DIFF
--- a/customize.dist/loading.js
+++ b/customize.dist/loading.js
@@ -15,7 +15,7 @@ define([
 
     elem.innerHTML = [
         '<div class="cp-loading-logo">',
-            '<img class="cp-loading-cryptofist" src="/api/logo?' + urlArgs + '" alt="' + Messages.label_logo + '">',
+            '<img class="cp-loading-cryptofist" src="/api/logo?' + urlArgs + '" alt="" aria-hidden="true">',
         '</div>',
         '<div class="cp-loading-container">',
             '<div class="cp-loading-spinner-container">',

--- a/customize.dist/loading.js
+++ b/customize.dist/loading.js
@@ -21,7 +21,7 @@ define([
             '<div class="cp-loading-spinner-container">',
                 '<span class="cp-spinner"></span>',
             '</div>',
-            '<div class="cp-loading-progress">',
+            '<div class="cp-loading-progress" aria-hidden="true" role="presentation">',
                 '<div class="cp-loading-progress-list"></div>',
                 '<div class="cp-loading-progress-container"></div>',
             '</div>',

--- a/customize.dist/src/less2/include/loading.less
+++ b/customize.dist/src/less2/include/loading.less
@@ -110,6 +110,7 @@
         overflow-y: auto;
         a {
             color: @cp_loading-link;
+            border-radius: @variables_radius;
         }
         p:last-child {
             margin-bottom: 0;

--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -1077,7 +1077,7 @@ define([
             $loading.css('display', '');
             $loading.removeClass('cp-loading-hidden');
             $loading.removeClass('cp-loading-transparent');
-            $loading.attr('aria-live','assertive');
+            $loading.attr('aria-live','polite');
             if (config.newProgress) {
                 var progress = h('div.cp-loading-progress', [
                     h('p.cp-loading-progress-list'),

--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -1036,7 +1036,7 @@ define([
             href: href,
             target: "_blank",
             'data-tippy-placement': "right",
-            'aria-label': text
+            'aria-label': Messages.help_genericMore //TBC XXX
         });
         return q;
     };

--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -1077,6 +1077,7 @@ define([
             $loading.css('display', '');
             $loading.removeClass('cp-loading-hidden');
             $loading.removeClass('cp-loading-transparent');
+            $loading.attr('aria-live','assertive');
             if (config.newProgress) {
                 var progress = h('div.cp-loading-progress', [
                     h('p.cp-loading-progress-list'),

--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -1036,7 +1036,7 @@ define([
             href: href,
             target: "_blank",
             'data-tippy-placement': "right",
-            'aria-label': Messages.help_genericMore //TBC XXX
+            'aria-label': text
         });
         return q;
     };

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3275,7 +3275,7 @@ define([
 
         var block = h('div#cp-loading-burn-after-reading', [
             info,
-            h('nav', {
+            h('section', {
                 style: 'text-align: right'
             }, button),
         ]);

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2649,8 +2649,8 @@ define([
         var $creationContainer = $('<div>', { id: 'cp-creation-container' }).appendTo($body);
         var urlArgs = (Config.requireConf && Config.requireConf.urlArgs) || '';
 
-        var logo = h('img', { src: '/customize/CryptPad_logo.svg?' + urlArgs });
-        var fill1 = h('div.cp-creation-fill.cp-creation-logo',{ role: 'presentation' }, logo);
+        var logo = h('img', { src: '/customize/CryptPad_logo.svg?' + urlArgs, alt:'', 'aria-hidden': 'true', role: 'presentation' });
+        var fill1 = h('div.cp-creation-fill.cp-creation-logo', logo);
         var fill2 = h('div.cp-creation-fill');
         var $creation = $('<div>', { id: 'cp-creation', tabindex:1 });
         $creationContainer.append([fill1, $creation, fill2]);

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -2649,8 +2649,8 @@ define([
         var $creationContainer = $('<div>', { id: 'cp-creation-container' }).appendTo($body);
         var urlArgs = (Config.requireConf && Config.requireConf.urlArgs) || '';
 
-        var logo = h('img', { src: '/customize/CryptPad_logo.svg?' + urlArgs, alt:'', 'aria-hidden': 'true', role: 'presentation' });
-        var fill1 = h('div.cp-creation-fill.cp-creation-logo', logo);
+        var logo = h('img', { src: '/customize/CryptPad_logo.svg?' + urlArgs });
+        var fill1 = h('div.cp-creation-fill.cp-creation-logo',{ role: 'presentation' }, logo);
         var fill2 = h('div.cp-creation-fill');
         var $creation = $('<div>', { id: 'cp-creation', tabindex:1 });
         $creationContainer.append([fill1, $creation, fill2]);


### PR DESCRIPTION
When a link to a document is received, users can either open the document or see a status/error message (eg: 'Document was destroyed by an owner'). These messages are now announced by screen readers. Also added visible outlines for links as a minor enhancement.