### PR TITLE
Fix missing recurring calendar after update

### DIFF
--- a/src/common/recurrence.js
+++ b/src/common/recurrence.js
@@ -687,7 +687,6 @@ const factory = (Util) => {
                         return;
                     }
 
-
                     var stop = false;
                     var newrule = false;
                     _toAdd.some(function (_newS) {
@@ -700,6 +699,11 @@ const factory = (Util) => {
                         _ev.start = +_evS;
                         _ev.end = +_evE;
                         _ev._count = c;
+
+                        Rec.applyUpdates([_ev]);
+                        _evS = new Date(_ev.start);
+                        _evE = new Date(_ev.end);
+
                         if (_ev.isAllDay && _ev.startDay) { _ev.startDay = getDateStr(_evS); }
                         if (_ev.isAllDay && _ev.endDay) { _ev.endDay = getDateStr(_evE); }
 

--- a/www/calendar/inner.js
+++ b/www/calendar/inner.js
@@ -997,7 +997,8 @@ define([
         // Mark selected months as done
         todo.forEach(function (monthId) { APP.recurringDone.push(monthId); });
 
-        cal.createSchedules(applyUpdates(toAdd));
+        //cal.createSchedules(applyUpdates(toAdd));
+        cal.createSchedules(toAdd);
     };
     updateRecurring = function () {
         try {


### PR DESCRIPTION
Events to render on the current month weren't taking into account the "day" modification of recurring events, resulting in some events not being displayed until the user loaded other months.

Example: We have an event repeating every two weeks and, at some point, we delay future occurrences by one week. If an event was supposed to occur on the last week of a month, it will now occur on the first week of the next month.
Our code was computing the events to render on a given month before updating the events with their time adjustment, meaning that in this example, the event that shifted its month wouldn't be rendered until the user computed both months (by moving back in the calendar view).