### PR TITLE
guard against misconfiguration of fileHost setting

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -98,7 +98,7 @@ module.exports.create = function (config) {
 
         protocol: new URL(httpUnsafeOrigin).protocol,
 
-        fileHost: config.fileHost || undefined,
+        fileHost: config.fileHost? new URL(config.fileHost).origin : undefined,
         NO_SANDBOX: NO_SANDBOX,
         httpSafePort: httpSafePort,
         websocketPort: config.websocketPort,


### PR DESCRIPTION
In the process of tinkering with my CryptPad instance I discovered that accidentally including a trailing slash for the `fileHost` setting in `config/config.js` breaks _blocks_ and _blobs_.

The reason is that there are a bunch of points in the code where if `fileHost` is present it will be directly prepended to those resources' file paths. When it is set to `https://files.myinstance.website/` rather than `https://files.myinstance.website`, this doubles up on the leading slash, and lots of things break.

This patch modifies the server to convert `fileHost` to the expected format if it is present, and to do nothing otherwise. I suppose it could break some non-standard uses of the value, such as if files are loaded from a subpath of another domain, but as far as I know that isn't supported behaviour.

Feel free to reject this PR in any case, but I figured it might save someone else the time I spent debugging the issue after my silly mistake.