### PR TITLE
Pad: Include media-tag CSS in print preview so images sized correctly

### DIFF
--- a/www/pad/mediatag-plugin.js
+++ b/www/pad/mediatag-plugin.js
@@ -4,31 +4,32 @@
 
 ( function() {
 
+    const mediaTagCss = (
+        'media-tag{' +
+            'display:inline-block;' +
+            'border-style: solid;' +
+            'border-color: black;' +
+            'border-width: 0;' +
+        '}' +
+        'media-tag.selected{' +
+            'border: 1px solid black;' +
+        '}' +
+        'media-tag iframe{' +
+            'border: 6px solid #eee;' +
+        '}' +
+        'media-tag img{' +
+            'vertical-align: top;' +
+        '}' +
+        'media-tag *{' +
+            'width:100%; height:100%;' +
+        '}');
+
     CKEDITOR.plugins.add( 'mediatag', {
         requires: 'dialog,widget',
         //icons: 'image',
         //hidpi: true,
         onLoad: function () {
-
-            CKEDITOR.addCss(
-            'media-tag{' +
-                'display:inline-block;' +
-                'border-style: solid;' +
-                'border-color: black;' +
-                'border-width: 0;' +
-            '}' +
-            'media-tag.selected{' +
-                'border: 1px solid black;' +
-            '}' +
-            'media-tag iframe{' +
-                'border: 6px solid #eee;' +
-            '}' +
-            'media-tag img{' +
-                'vertical-align: top;' +
-            '}' +
-            'media-tag *{' +
-                'width:100%; height:100%;' +
-            '}');
+            CKEDITOR.addCss(mediaTagCss);
         },
         init: function( editor ) {
             var pluginName = 'mediatag';
@@ -130,6 +131,16 @@
                     }
                 });
             }
+
+            // Add CSS style to print preview, so media like images are sized the same
+            // as their enclosing `media-tag` elements, in other words sized correctly.
+            // Inspired by https://github.com/ckeditor/ckeditor4/blob/c7e59ec199298b6b23f4aa7a7668f18572385bac/plugins/mathjax/plugin.js#L136-L141
+            editor.on( 'contentPreview', function( evt ) {
+                evt.data.dataValue = evt.data.dataValue.replace(
+                    /<\/head>/,
+                    '<style>'+mediaTagCss+'<\/style><\/head>'
+                );
+            } );
 
         },
     } );


### PR DESCRIPTION
Fixes #2037 

This patch does not change the HTML of the documents produced by the editor, so should be backwards-compatible with documents containing images previously sized using the dialog.

The fundamental requirement is to make a piece of CSS exist in both the editor and print preview window. Here's a method using a regular expression and the `contentPreview` event to directly insert the CSS into the HTML, since it's what CKEditor's own MathJax plugin does (for a JavaScript import).

This isn't disgusting, in my opinion. Nevertheless, there may be a better, cleaner way, but `CKEDITOR.addCss` is not it. Please let me know if there is one you know of. I don't know whether CKEditor 5 does this in a cleaner way, but it would be easier to suggest a cleaner approach upstream in CKEditor's repository if Cryptpad used CKEditor 5. That might be a good (but difficult) idea for the long-term because the CKEditor 4 we use is no longer supported.