### PR TITLE
Correct navigation to shared folders

### DIFF
--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -1274,6 +1274,10 @@ define([
         var refresh = APP.refresh = function (cb, opt) {
             var type = APP.store[FILTER_BY];
             var path = type ? [FILTER, type, currentPath] : currentPath;
+                if (APP.newSharedFolder && priv.anonSFHref && opt) {
+                    opt.sf = true
+                }
+
             APP.displayDirectory(path, undefined, () => {
                 refreshDeprecated();
                 if (typeof(cb) === "function") { cb(); }
@@ -4330,7 +4334,7 @@ define([
             var $folderHeader = getFolderListHeader(true);
             var $fileHeader = getFileListHeader(true);
             var path = currentPath.slice(1);
-            var root = Util.find(data, path);
+            var root = Util.find(data, path) ? Util.find(data, path) : ['root'];
 
             var realPath = [ROOT, SHARED_FOLDER].concat(path);
 
@@ -4377,11 +4381,13 @@ define([
                 } else {
                     path = [ROOT];
                 }
-            } else if (driveConfig.APP.loggedIn && path[0] === 'sf') {
+            } else if (APP.loggedIn && path[0] === 'sf') {
                 var fId = APP.newSharedFolder;
-                const key = Object.keys(proxy.drive.root).find(
-                    k => proxy.drive.root[k] === parseInt(fId)
-                );
+
+                const key = Object.entries(proxy.drive.root).find(
+                ([_, value]) => value === Number(APP.newSharedFolder)
+                )?.[0];
+
                 path = ['root', String(key),'root'];
             }
 
@@ -4629,6 +4635,10 @@ define([
                     //  Wait for shared folder metadata
                     // _displayDirectory(path, force);
                     // cb();
+                }
+                if (opt?.sf) {
+                    path = ['sf', String(APP.newSharedFolder), 'root'];
+
                 }
                 updateSharedFolders(sframeChan, manager, files, folders, function () {
                     _displayDirectory(path, force);

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -4383,7 +4383,7 @@ define([
             } else if (APP.loggedIn && path[0] === 'sf') {
 
                 const key = Object.entries(proxy.drive.root).find(
-                ([key, value]) => value === Number(APP.newSharedFolder)
+                ([, value]) => value === Number(APP.newSharedFolder)
                 )?.[0];
 
                 path = ['root', String(key), 'root'];

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -1275,7 +1275,7 @@ define([
             var type = APP.store[FILTER_BY];
             var path = type ? [FILTER, type, currentPath] : currentPath;
                 if (APP.newSharedFolder && priv.anonSFHref && opt) {
-                    opt.sf = true
+                    opt.sf = true;
                 }
 
             APP.displayDirectory(path, undefined, () => {
@@ -2767,6 +2767,7 @@ define([
             path.forEach(function (p, idx) {
                 if (isTrash && [2,3].indexOf(idx) !== -1) { return; }
                 if (skipNext) { skipNext = false; return; }
+                if ( idx > 0 && p === ROOT && path[0] === SHARED_FOLDER ) { return; }
                 if (APP.newSharedFolder && priv.isEmbed && p === ROOT && !idx) { return; }
                 var name = p;
 
@@ -2792,6 +2793,7 @@ define([
 
                 var $span = $('<span>', {'class': 'cp-app-drive-path-element'});
                 if (idx < path.length - 1) {
+
                     if (!noStyle) {
                         $span.addClass('cp-app-drive-path-clickable');
                         $span.click(function (e) {
@@ -2805,6 +2807,7 @@ define([
                     name = getElementName(path);
                 }
                 $span.data("path", path.slice(0, idx + 1));
+
                 addDragAndDropHandlers($span, path.slice(0, idx), true, true);
 
                 if (idx === 0) { name = p === SHARED_FOLDER ? name : getPrettyName(p); }
@@ -4334,7 +4337,7 @@ define([
             var $folderHeader = getFolderListHeader(true);
             var $fileHeader = getFileListHeader(true);
             var path = currentPath.slice(1);
-            var root = Util.find(data, path) ? Util.find(data, path) : ['root'];
+            var root = Util.find(data, path) ? Util.find(data, path) : {};
             var realPath = [ROOT, SHARED_FOLDER].concat(path);
 
             if (manager.hasSubfolder(root)) { $list.append($folderHeader); }
@@ -4381,13 +4384,12 @@ define([
                     path = [ROOT];
                 }
             } else if (APP.loggedIn && path[0] === 'sf') {
-                var fId = APP.newSharedFolder;
 
                 const key = Object.entries(proxy.drive.root).find(
-                ([_, value]) => value === Number(APP.newSharedFolder)
+                ([value]) => value === Number(APP.newSharedFolder)
                 )?.[0];
 
-                path = ['root', String(key),'root'];
+                path = ['root', String(key), 'root'];
             }
 
             if (APP.loggedIn && path[0] === FILES_DATA) {

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -1274,9 +1274,9 @@ define([
         var refresh = APP.refresh = function (cb, opt) {
             var type = APP.store[FILTER_BY];
             var path = type ? [FILTER, type, currentPath] : currentPath;
-                if (APP.newSharedFolder && priv.anonSFHref && opt) {
-                    opt.sf = true;
-                }
+            if (APP.newSharedFolder && priv.anonSFHref && opt) {
+                opt.sf = true;
+            }
 
             APP.displayDirectory(path, undefined, () => {
                 refreshDeprecated();
@@ -4335,7 +4335,7 @@ define([
             var $folderHeader = getFolderListHeader(true);
             var $fileHeader = getFileListHeader(true);
             var path = currentPath.slice(1);
-            var root = Util.find(data, path) ? Util.find(data, path) : {};
+            var root = Util.find(data, path) || {};
             var realPath = [ROOT, SHARED_FOLDER].concat(path);
 
             if (manager.hasSubfolder(root)) { $list.append($folderHeader); }

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -4335,7 +4335,6 @@ define([
             var $fileHeader = getFileListHeader(true);
             var path = currentPath.slice(1);
             var root = Util.find(data, path) ? Util.find(data, path) : ['root'];
-
             var realPath = [ROOT, SHARED_FOLDER].concat(path);
 
             if (manager.hasSubfolder(root)) { $list.append($folderHeader); }

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -2793,7 +2793,6 @@ define([
 
                 var $span = $('<span>', {'class': 'cp-app-drive-path-element'});
                 if (idx < path.length - 1) {
-
                     if (!noStyle) {
                         $span.addClass('cp-app-drive-path-clickable');
                         $span.click(function (e) {
@@ -2807,7 +2806,6 @@ define([
                     name = getElementName(path);
                 }
                 $span.data("path", path.slice(0, idx + 1));
-
                 addDragAndDropHandlers($span, path.slice(0, idx), true, true);
 
                 if (idx === 0) { name = p === SHARED_FOLDER ? name : getPrettyName(p); }
@@ -4363,7 +4361,6 @@ define([
         // Display the selected directory into the content part (rightside)
         // NOTE: Elements in the trash are not using the same storage structure as the others
         var _displayDirectory = function (path, force) {
-
             if (APP.closed || (APP.$content && !$.contains(document.documentElement, APP.$content[0]))) { return; }
 
             APP.hideMenu();
@@ -4386,7 +4383,7 @@ define([
             } else if (APP.loggedIn && path[0] === 'sf') {
 
                 const key = Object.entries(proxy.drive.root).find(
-                ([value]) => value === Number(APP.newSharedFolder)
+                ([key, value]) => value === Number(APP.newSharedFolder)
                 )?.[0];
 
                 path = ['root', String(key), 'root'];

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -4357,6 +4357,7 @@ define([
         // Display the selected directory into the content part (rightside)
         // NOTE: Elements in the trash are not using the same storage structure as the others
         var _displayDirectory = function (path, force) {
+
             if (APP.closed || (APP.$content && !$.contains(document.documentElement, APP.$content[0]))) { return; }
 
             APP.hideMenu();
@@ -4376,6 +4377,12 @@ define([
                 } else {
                     path = [ROOT];
                 }
+            } else if (driveConfig.APP.loggedIn && path[0] === 'sf') {
+                var fId = APP.newSharedFolder;
+                const key = Object.keys(proxy.drive.root).find(
+                    k => proxy.drive.root[k] === parseInt(fId)
+                );
+                path = ['root', String(key),'root'];
             }
 
             if (APP.loggedIn && path[0] === FILES_DATA) {

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -2335,7 +2335,7 @@ define([
             // If our channel was deleted from all of our drives, sitch back to full hash
             // in the address bar
             Cryptpad.padRpc.onChannelDeleted.reg(function (channel) {
-                if (channel !== secret.channel) { return; }
+                if (channel !== secret.channel || currentPad.app === 'drive') { return; }
                 Cryptpad.setTabHref(currentPad.href);
             });
 


### PR DESCRIPTION
- fixes #2275 (when opening a link to a shared folder as a guest user, then logging in, the user is correctly redirected to the shared folder instead of a script error being thrown)
- fixes #2327 (when opening a link to shared folder as a logged in user, the user is correctly redirected to the shared folder instead of the drive root)
- fixes #2337 (address bar no longer navigates to shared folder hash when attempting to remove it from drive)