### PR TITLE
Questions stay as 'required' when edited

### DIFF
--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -668,7 +668,11 @@ define([
                     if (hasUid) { $(el).data('uid', uid); }
                 });
             }
+
             var res = { values: values };
+            if (v.required) {
+                res['required'] = true;
+            }
 
             // If multiline block, get items
             if (v.items) {


### PR DESCRIPTION
- fixes #2255 (form questions no longer lose 'required' property when edited)