### PR TITLE
Fixed error propagation in integration mode

### DIFF
--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -2266,7 +2266,7 @@ define([
                 sframeChan.on('Q_INTEGRATION_USERLIST_CHANGE', function (obj, cb) {
                     cfg?.integrationUtils?.onUserlistChange?.(obj, cb);
                 });
-                sframeChan.on('Q_INTEGRATION_ERROR', function (obj) {
+                sframeChan.on('EV_INTEGRATION_ERROR', function (obj) {
                     if (cfg.integrationUtils && cfg.integrationUtils.onError) {
                         cfg.integrationUtils.onError(obj);
                     }


### PR DESCRIPTION
In integration mode, I've noticed some errors were detected but `onError` was not called and the "parent" app was not informed.

`sframe-common-outer` listens to `Q_INTEGRATION_ERROR`, which doesn't seem to exist (a grep doesn't return anything) instead of `EV_INTEGRATION_ERROR`.