### PR TITLE
Notification fixes

### DIFF
--- a/customize.dist/src/less2/include/notifications.less
+++ b/customize.dist/src/less2/include/notifications.less
@@ -17,14 +17,6 @@
         margin-right: @variables_icon_margin;
     }
     @notif-height: 50px;
-    .cp-app-notifications-panel-list {
-        .cp-avatar-image {
-            img {
-                max-height: 50px;
-                margin: 10px;
-            }
-        }
-    }
 
     .cp-notifications-container {
         max-width: 300px;

--- a/customize.dist/src/less2/include/notifications.less
+++ b/customize.dist/src/less2/include/notifications.less
@@ -17,6 +17,15 @@
         margin-right: @variables_icon_margin;
     }
     @notif-height: 50px;
+    .cp-app-notifications-panel-list {
+        .cp-avatar-image {
+            img {
+                max-height: 50px;
+                margin: 10px;
+            }
+        }
+    }
+
     .cp-notifications-container {
         max-width: 300px;
         width: 300px;
@@ -55,6 +64,7 @@
                 justify-content: center;
                 img {
                     height: 40px;
+                    margin: 5px;
                 }
             }
             .cp-notification-content {

--- a/customize.dist/src/less2/include/notifications.less
+++ b/customize.dist/src/less2/include/notifications.less
@@ -17,7 +17,6 @@
         margin-right: @variables_icon_margin;
     }
     @notif-height: 50px;
-
     .cp-notifications-container {
         max-width: 300px;
         width: 300px;

--- a/www/common/sframe-common-mailbox.js
+++ b/www/common/sframe-common-mailbox.js
@@ -13,8 +13,6 @@ define([
     '/customize/application_config.js',
     '/customize/messages.js',
     '/common/common-icons.js',
-    'less!/notifications/app-notifications.less',
-
 ], function ($, Util, Hash, UI, UIElements, Notifications, h, AppConfig, Messages, Icons) {
     var Mailbox = {};
 

--- a/www/common/sframe-common-mailbox.js
+++ b/www/common/sframe-common-mailbox.js
@@ -13,6 +13,8 @@ define([
     '/customize/application_config.js',
     '/customize/messages.js',
     '/common/common-icons.js',
+    'less!/notifications/app-notifications.less',
+
 ], function ($, Util, Hash, UI, UIElements, Notifications, h, AppConfig, Messages, Icons) {
     var Mailbox = {};
 

--- a/www/notifications/app-notifications.less
+++ b/www/notifications/app-notifications.less
@@ -84,7 +84,6 @@
                     margin: 10px;
                 }
             }
-
             .cp-notification {
                 display: flex;
                 flex-direction: row;

--- a/www/notifications/app-notifications.less
+++ b/www/notifications/app-notifications.less
@@ -78,6 +78,13 @@
             border-top: none;
             overflow: hidden;
 
+            .cp-avatar-image {
+                img {
+                    max-height: 50px;
+                    margin: 10px;
+                }
+            }
+
             .cp-notification {
                 display: flex;
                 flex-direction: row;

--- a/www/notifications/inner.js
+++ b/www/notifications/inner.js
@@ -154,8 +154,7 @@ define([
             notifsList.after(loadmore);
             $(loadmore).click();
         }
-
-        common.mailbox.subscribe(["notifications", "reminders"], {
+        common.mailbox.subscribe(['notifications', 'team', 'broadcast', 'reminders', 'supportteam'], {
             onMessage: function (data, el) {
                 addNotification(data, el);
             },


### PR DESCRIPTION
- fixes #1482 (notifications about documents shared to teams now show up in notification panel; instance logo in notifications about answers to support tickets no longer mis-sized/mis-positioned)