### PR TITLE
Fix #2304: Update UI for 'Present' mode

### DIFF
--- a/www/common/sframe-app-framework.js
+++ b/www/common/sframe-app-framework.js
@@ -996,27 +996,30 @@ define([
             title.setToolbar(toolbar);
 
             /* add a history button */
-            var histConfig = {
-                onLocal: onLocal,
-                onRemote: onRemote,
-                setHistory: setHistoryMode,
-                extractMetadata: extractMetadata, // extract from current version
-                getLastMetadata: getLastMetadata, // get from authdoc
-                setLastMetadata: setLastMetadata, // set to userdoc/authdoc
-                applyVal: function (val) {
-                    var newContent = JSON.parse(val);
-                    var meta = extractMetadata(newContent);
-                    cpNfInner.metadataMgr.updateMetadata(meta);
-                    contentUpdate(normalize(newContent) || ["BODY",{},[]], function (h) {
-                        return h;
-                    });
-                },
-                $toolbar: $(toolbarContainer)
-            };
-            var $histButton = common.createButton('history', true, {histConfig: histConfig});
-            var $hist = UIElements.getEntryFromButton($histButton);
-            toolbar.$drawer.append($hist);
-
+            var privateDat = cpNfInner.metadataMgr.getPrivateData();
+            if (!(privateDat.isPresent && privateDat.app === 'code')) {
+                var histConfig = {
+                    onLocal: onLocal,
+                    onRemote: onRemote,
+                    setHistory: setHistoryMode,
+                    extractMetadata: extractMetadata, // extract from current version
+                    getLastMetadata: getLastMetadata, // get from authdoc
+                    setLastMetadata: setLastMetadata, // set to userdoc/authdoc
+                    applyVal: function (val) {
+                        var newContent = JSON.parse(val);
+                        var meta = extractMetadata(newContent);
+                        cpNfInner.metadataMgr.updateMetadata(meta);
+                        contentUpdate(normalize(newContent) || ["BODY",{},[]], function (h) {
+                            return h;
+                        });
+                    },
+                    $toolbar: $(toolbarContainer)
+                };
+                var $histButton = common.createButton('history', true, {histConfig: histConfig});
+                var $hist = UIElements.getEntryFromButton($histButton);
+                toolbar.$drawer.append($hist);
+            }
+            
             var $snapshotButton = common.createButton('snapshots', true, {
                 remove: deleteSnapshot,
                 make: makeSnapshot,


### PR DESCRIPTION
Fixes #2304

## Problem
In Code documents shared in 'Present' mode, the option to browse History appears although it doesn't work when the user attempts to do so (no changes are reverted in the document, which stays as-is). The UI should be updated to remove the 'History' option for Code documents shared in this mode.

## Solution
Added an if block which checks if isPresent Mode true or false and then creates history button accordingly