### PR TITLE
Fix drive context menu "New Link" opening a Rich Text document

### DIFF
--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -498,6 +498,7 @@ define([
                 $separator.clone()[0],
                 h('li', h('a.cp-app-drive-context-newdoc.dropdown-item.cp-app-drive-context-editable', {
                     'tabindex': '-1',
+                    'data-type': 'link',
                 },[
                     Icons.get('link'),
                     Messages.fm_link_new


### PR DESCRIPTION
This PR aims to fix the misdirection caused by the handler falling back to `pad` when `data-type` is missing