### PR TITLE
Restoring a document removes “expire” value from metadata if expired

### DIFF
--- a/lib/storage/file.js
+++ b/lib/storage/file.js
@@ -873,23 +873,26 @@ var unarchiveChannel = function (env, channelName, cb) {
             // remove the `expire` date if it is overdue (probably mistakenly
             // expired pad)
             Fs.readFile(metadataPath, (readError, content) => {
-                content = content.toString();
-                const expireExpr = /"expire":(\d+),/;
                 if (readError) {
                     return CB(readError.code);
                 }
-                let expireDate = expireExpr.exec(content);
-                if (expireDate) {
-                    if (expireDate.length !== 2) {
-                        return CB('INVALID_METADATA');
-                    }
-                    expireDate = parseInt(expireDate[1]);
+                try {
+                    let metadataArray = content.toString().split('\n');
+                    let metadata = JSON.parse(metadataArray[0]);
+                    let expireDate = metadata?.expire;
                     // check that it’s indeed expired
                     if (expireDate && +new Date() >= expireDate) {
-                        return Fs.writeFile(metadataPath, content.replace(expireExpr, ''), CB);
+                        delete metadata.expire;
+                        metadataArray[0] = JSON.stringify(metadata);
+                        return Fs.writeFile(metadataPath, metadataArray.join('\n'), CB);
                     }
+                    CB();
                 }
-                CB();
+                catch(err) {
+                    // Most probably a JSON.parse error: invalid metadata
+                    // The file would have been restored “as is” at this point
+                    CB('INVALID_METADATA');
+                };
             });
         }));
     });

--- a/lib/storage/file.js
+++ b/lib/storage/file.js
@@ -869,7 +869,28 @@ var unarchiveChannel = function (env, channelName, cb) {
                 return void CB(labelError("E_METADATA_RESTORATION", err));
             }
             // otherwise it was moved successfully
-            CB();
+
+            // remove the `expire` date if it is overdue (probably mistakenly
+            // expired pad)
+            Fs.readFile(metadataPath, (readError, content) => {
+                content = content.toString();
+                const expireExpr = /"expire":(\d+),/;
+                if (readError) {
+                    return CB(readError.code);
+                }
+                let expireDate = expireExpr.exec(content);
+                if (expireDate) {
+                    if (expireDate.length !== 2) {
+                        return CB('INVALID_METADATA');
+                    }
+                    expireDate = parseInt(expireDate[1]);
+                    // check that it’s indeed expired
+                    if (expireDate && +new Date() >= expireDate) {
+                        return Fs.writeFile(metadataPath, content.replace(expireExpr, ''), CB);
+                    }
+                }
+                CB();
+            });
         }));
     });
 };

--- a/lib/storage/file.js
+++ b/lib/storage/file.js
@@ -859,7 +859,7 @@ var unarchiveChannel = function (env, channelName, cb) {
             if (err && err.code === 'ENOENT') {
                 if (ENOENT) {
                     // nothing was deleted? the client probably wants to know about that.
-                    return void cb("ENOENT");
+                    return void CB("ENOENT");
                 }
                 return CB();
             }

--- a/lib/storage/file.js
+++ b/lib/storage/file.js
@@ -874,7 +874,8 @@ var unarchiveChannel = function (env, channelName, cb) {
             // expired pad)
             Fs.readFile(metadataPath, (readError, content) => {
                 if (readError) {
-                    return CB(readError.code);
+                    if (readError.code === 'ENOENT') { return void CB(); }
+                    return CB(labelError("E_METADATA_RESTORATION", readError));
                 }
                 try {
                     let metadataArray = content.toString().split('\n');


### PR DESCRIPTION
Fixes #2310 

When restoring an expired document from the admin panel, the information stayed in the metadata, blocking the file loading with the “This document has reached its destruction date and is no longer available.” error message.

This PR aims at fixing this behaviour by checking the expire property from metadata and removing it if the file already expired (expiry date check avoid having to check the placeholder, which has already been cleared at this point of the code).

Note that `blobs` can’t expire and thus are not subject to this change.

This PR also fixes a typo in `unarchiveChannel`.