### PR TITLE
Restore focus to OnlyOffice editor

### DIFF
--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -76,6 +76,7 @@ define([
 
     UI.removeModals = function () {
         $('div.alertify').remove();
+        restoreModalFocus();
     };
 
     var listenForKeys = UI.listenForKeys = function (yes, no, el) {
@@ -123,6 +124,16 @@ define([
     };
 
     var dialog = UI.dialog = {};
+    var savedModalFocus = null;
+    var restoreModalFocus = function () {
+        if (!savedModalFocus) { return; }
+        if (savedModalFocus.nodeName === "IFRAME") {
+            $(savedModalFocus.contentWindow).focus();
+        } else {
+            $(savedModalFocus).focus();
+        }
+        savedModalFocus = null;
+    };
 
     var merge = function (a, b) {
         var c = {};
@@ -221,10 +232,15 @@ define([
         dialogContent.setAttribute('aria-modal', 'true');
 
         var $frame = $(frame);
+        $frame.on('mousedown', function () {
+            savedModalFocus = document.activeElement;
+        });
+
         frame.closeModal = function (cb) {
             frame.closeModal = function () {}; // Prevent further calls
             $frame.fadeOut(150, function () {
                 $frame.detach();
+                restoreModalFocus();
                 if (typeof(cb) === "function") { cb(); }
             });
         };
@@ -1470,6 +1486,11 @@ define([
 
         var $popup = $(popup);
 
+        var savedFocus;
+        $popup.on('mousedown', function () {
+            savedFocus = document.activeElement;
+        });
+
         if (opts.big) {
             $popup.addClass('cp-corner-big');
         }
@@ -1485,6 +1506,13 @@ define([
         };
         var deletePopup = function () {
             $popup.remove();
+            if (savedFocus) {
+                if (savedFocus.nodeName === "IFRAME") {
+                    $(savedFocus.contentWindow).focus();
+                } else {
+                    $(savedFocus).focus();
+                }
+            }
             if (!corner.queue.length) {
                 // Make sure no other popup is displayed in the next 5s
                 setTimeout(function () {

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3528,12 +3528,17 @@ define([
             e.preventDefault();
             common.openURL('/settings/');
         });
-
+        // $(hide).on('mousedown', function (e) {
+        //     e.preventDefault();
+        // });
         $(hide).click(function () {
             delete autoStoreModal[priv.channel];
             $('.cp-toolbar-storeindrive').show();
             modal.delete();
         });
+        // $(store).on('mousedown', function (e) {
+        //     e.preventDefault();
+        // });
         var waitingForStoringCb = false;
         $(store).click(function () {
             if (waitingForStoringCb) { return; }

--- a/www/common/onlyoffice/inner.js
+++ b/www/common/onlyoffice/inner.js
@@ -2681,6 +2681,8 @@ Uncaught TypeError: Cannot read property 'calculatedType' of null
                 getImageURL: getImageURL,
                 getInitialChanges: getInitialChanges,
             });
+
+            
         };
 
         APP.printPdf = function (obj, cb) {

--- a/www/common/toolbar.js
+++ b/www/common/toolbar.js
@@ -488,6 +488,14 @@ MessengerUI, Messages, Pages, PadTypes, Icons) {
             hide();
         });
         */
+        let focus;
+        $button.on('mousedown', function () {
+            focus = document.activeElement;
+        });
+        let focus;
+        $button.on('mousedown', function () {
+            focus = document.activeElement;
+        });
         $button.click(function () {
             var visible = $content.is(':visible');
             if (visible) { hide(); }
@@ -495,6 +503,12 @@ MessengerUI, Messages, Pages, PadTypes, Icons) {
             visible = !visible;
             Common.setAttribute(['toolbar', 'userlist-drawer'], visible);
             Feedback.send(visible?'USERLIST_SHOW': 'USERLIST_HIDE');
+
+            if (focus.nodeName === "IFRAME") {
+                $(focus.contentWindow).focus();
+            } else {
+                $(focus).focus();
+            }
         });
         show();
         Common.getAttribute(['toolbar', 'userlist-drawer'], function (err, val) {
@@ -617,12 +631,22 @@ MessengerUI, Messages, Pages, PadTypes, Icons) {
             hide(true);
         });
         */
+        let focus;
+        $button.on('mousedown', function () {
+            focus = document.activeElement;
+        });
         $button.click(function () {
             var visible = $content.is(':visible');
             if (visible) { hide(true); }
             else { show(); }
             visible = !visible;
             Common.setAttribute(['toolbar', 'chat-drawer'], visible);
+
+            if (focus.nodeName === "IFRAME") {
+                $(focus.contentWindow).focus();
+            } else {
+                $(focus).focus();
+            }
         });
         show();
         Common.getAttribute(['toolbar', 'chat-drawer'], function (err, val) {


### PR DESCRIPTION
- fixes #2269 (returns focus to OnlyOffice editor after interacting with CryptPad UI elements and prevents editor from becoming unresponsive)