### PR TITLE
Fix infinite wait on Team trim history upon failure

### DIFF
--- a/src/worker/modules/history.js
+++ b/src/worker/modules/history.js
@@ -161,9 +161,18 @@ const factory = (Util, Hash, UserObject, nThen) => {
 
                     hash = obj[0].hash;
                     var messages = obj.map(function(data) {
-                        return data.msg;
+                        try {
+                            // Remove txid from received messages
+                            let parsed = JSON.parse(data.msg);
+                            parsed[0] = 0;
+                            return JSON.stringify(parsed);
+                        } catch (e) {
+                            // Invalid message in history: should not happen
+                            return data.msg;
+                        }
                     });
-                    dataSize = messages.join('\n').length;
+                    // +1 is there for the last new line
+                    dataSize = messages.join('\n').length + 1;
                 }), true);
             }
             // Metadata
@@ -172,7 +181,8 @@ const factory = (Util, Hash, UserObject, nThen) => {
             }, waitFor(function (obj) {
                 if (obj && obj.error) { return; }
                 if (!obj || typeof(obj) !== "object") { return; }
-                metadata = JSON.stringify(obj).length;
+                // +1 is there for the last new line
+                metadata = JSON.stringify(obj).length + 1;
                 if (!obj || !Array.isArray(obj.owners) ||
                     obj.owners.indexOf(edPublic) === -1) {
                     waitFor.abort();

--- a/www/teams/inner.js
+++ b/www/teams/inner.js
@@ -429,10 +429,16 @@ define([
             ]);
             UI.openCustomModal(UI.dialog.customModal(div, {buttons: []}));
             console.log('Trimming team history', APP.team, size);
+            const removeModalsTimeout = setTimeout(() => {
+                UI.removeModals();
+                Feedback.send(`TRIM_HISTORY_TIMEOUT=${channels.map(obj => obj?.channel).join('|')}`, true);
+                UI.warn(Messages.trimHistory_error);
+            }, 120000);
             APP.history.execCommand('TRIM_HISTORY', {
                 channels: channels
             }, function(obj) {
                 if (obj && obj.error) { console.error(obj.error); }
+                clearTimeout(removeModalsTimeout);
                 UI.removeModals();
             });
         });

--- a/www/teams/inner.js
+++ b/www/teams/inner.js
@@ -433,7 +433,7 @@ define([
                 UI.removeModals();
                 Feedback.send(`TRIM_HISTORY_TIMEOUT=${channels.map(obj => obj?.channel).join('|')}`, true);
                 UI.warn(Messages.trimHistory_error);
-            }, 120000);
+            }, 15000);
             APP.history.execCommand('TRIM_HISTORY', {
                 channels: channels
             }, function(obj) {


### PR DESCRIPTION
When a team owner is trimming their history and it fails, they are locked out of their team for indefinite time.

This PR adds the following:
- a timeout in order not to lock owners out of their team, raising a warning for the end user;
- a fix in the computation of the history size to be accurate with what is stored on the server.

Note: need to rebuild the worker after merging