### PR TITLE
Restore OO editor focus

### DIFF
--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -73,9 +73,20 @@ define([
         }
         return $('button.ok').last();
     };
+    var savedModalFocus = null;
+    var restoreModalFocus = function () {
+        if (!savedModalFocus) { return; }
+        if (savedModalFocus.nodeName === "IFRAME") {
+            $(savedModalFocus.contentWindow).focus();
+        } else {
+            $(savedModalFocus).focus();
+        }
+        savedModalFocus = null;
+    };
 
     UI.removeModals = function () {
         $('div.alertify').remove();
+        restoreModalFocus();
     };
 
     var listenForKeys = UI.listenForKeys = function (yes, no, el) {
@@ -221,10 +232,14 @@ define([
         dialogContent.setAttribute('aria-modal', 'true');
 
         var $frame = $(frame);
+        $frame.on('mousedown', function () {
+            savedModalFocus = document.activeElement;
+        });
         frame.closeModal = function (cb) {
             frame.closeModal = function () {}; // Prevent further calls
             $frame.fadeOut(150, function () {
                 $frame.detach();
+                restoreModalFocus();
                 if (typeof(cb) === "function") { cb(); }
             });
         };
@@ -1469,7 +1484,10 @@ define([
         ]);
 
         var $popup = $(popup);
-
+        var savedFocus;
+        $popup.on('mousedown', function () {
+            savedFocus = document.activeElement;
+        });
         if (opts.big) {
             $popup.addClass('cp-corner-big');
         }
@@ -1485,6 +1503,13 @@ define([
         };
         var deletePopup = function () {
             $popup.remove();
+            if (savedFocus) {
+                if (savedFocus.nodeName === "IFRAME") {
+                    $(savedFocus.contentWindow).focus();
+                } else {
+                    $(savedFocus).focus();
+                }
+            }
             if (!corner.queue.length) {
                 // Make sure no other popup is displayed in the next 5s
                 setTimeout(function () {

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3528,12 +3528,21 @@ define([
             e.preventDefault();
             common.openURL('/settings/');
         });
+        
+        $(hide).on('mousedown', function (e) {
+            e.preventDefault();
+        });
 
         $(hide).click(function () {
             delete autoStoreModal[priv.channel];
             $('.cp-toolbar-storeindrive').show();
             modal.delete();
         });
+
+        $(store).on('mousedown', function (e) {
+            e.preventDefault();
+        });
+
         var waitingForStoringCb = false;
         $(store).click(function () {
             if (waitingForStoringCb) { return; }

--- a/www/common/toolbar.js
+++ b/www/common/toolbar.js
@@ -488,6 +488,11 @@ MessengerUI, Messages, Pages, PadTypes, Icons) {
             hide();
         });
         */
+        $button.on('mousedown', function (e) {
+            if (document.activeElement && document.activeElement.nodeName === 'IFRAME') {
+                e.preventDefault();
+            }
+        });
         $button.click(function () {
             var visible = $content.is(':visible');
             if (visible) { hide(); }
@@ -617,6 +622,11 @@ MessengerUI, Messages, Pages, PadTypes, Icons) {
             hide(true);
         });
         */
+        $button.on('mousedown', function (e) {
+            if (document.activeElement && document.activeElement.nodeName === 'IFRAME') {
+                e.preventDefault();
+            }
+        });
         $button.click(function () {
             var visible = $content.is(':visible');
             if (visible) { hide(true); }


### PR DESCRIPTION
- fixes #2269 (prevents OnlyOffice editor from "locking" after interaction with Store popup/Chat/User drawer by restoring focus)